### PR TITLE
Fix UnorderedObjectListWarning in all paginated views

### DIFF
--- a/krill/person/models.py
+++ b/krill/person/models.py
@@ -53,6 +53,7 @@ class UserRole(models.Model):
             )
 
     class Meta:
+        ordering = ['user__username']
         verbose_name = "User Role"
         verbose_name_plural = "User Roles"
 
@@ -184,6 +185,7 @@ class Permission(models.Model):
     expires_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
+        ordering = ['user__username', 'permission_type']
         unique_together = ['user', 'permission_type', 'content_type', 'object_id']
         verbose_name = "Permission"
         verbose_name_plural = "Permissions"

--- a/krill/person/views.py
+++ b/krill/person/views.py
@@ -667,7 +667,7 @@ def create_user(request):
 def user_list(request):
     """List all users with their roles and permissions"""
     form = UserSearchForm(request.GET)
-    users = UserRole.objects.select_related('user').all()
+    users = UserRole.objects.select_related('user').order_by('user__username')
     if form.is_valid():
         search = form.cleaned_data.get('search')
         role = form.cleaned_data.get('role')
@@ -759,7 +759,7 @@ def user_role_edit(request, user_id):
 @require_minimum_role('lab_manager')
 def permission_list(request):
     """List all object-level permissions"""
-    permissions = Permission.objects.select_related('user', 'content_type', 'granted_by').all()
+    permissions = Permission.objects.select_related('user', 'content_type', 'granted_by').order_by('user__username', 'permission_type')
     # Filtering
     user_filter = request.GET.get('user')
     permission_type_filter = request.GET.get('permission_type')
@@ -858,7 +858,7 @@ def bulk_grant_permission(request):
 def audit_log(request):
     """View user audit logs"""
     form = AuditLogFilterForm(request.GET)
-    logs = UserAuditLog.objects.select_related('user').all()
+    logs = UserAuditLog.objects.select_related('user').order_by('-timestamp')
     if form.is_valid():
         user = form.cleaned_data.get('user')
         action = form.cleaned_data.get('action')

--- a/krill/sample/models/aliquot.py
+++ b/krill/sample/models/aliquot.py
@@ -45,6 +45,9 @@ class Aliquot(models.Model):
     deleted = models.BooleanField(default=False)
     deleted_at = models.DateTimeField(null=True, blank=True)
 
+    class Meta:
+        ordering = ['sample__name', 'id']
+
     def __str__(self):
         return f"{self.sample.name} - Aliquot {self.id}"
 

--- a/krill/sample/models/sample.py
+++ b/krill/sample/models/sample.py
@@ -19,5 +19,8 @@ class Sample(models.Model):
         help_text="Restrict access to specific user tiers"
     )
 
+    class Meta:
+        ordering = ['name']
+
     def __str__(self):
         return self.name

--- a/krill/sample/views/search.py
+++ b/krill/sample/views/search.py
@@ -16,7 +16,7 @@ def sample_search(request):
     disposition = request.GET.get('disposition', '')
 
     # Start with all samples
-    samples = Sample.objects.all()
+    samples = Sample.objects.order_by('name')
 
     if query:
         samples = samples.filter(
@@ -75,7 +75,7 @@ def aliquot_search(request):
         'aliquot_type'
     ).prefetch_related(
         'aliquotlocation_set__box'
-    ).all()
+    ).order_by('sample__name', 'id')
 
     if query:
         aliquots = aliquots.filter(


### PR DESCRIPTION
## 🐛 Fix: UnorderedObjectListWarning in all paginated views

This PR resolves **all** `UnorderedObjectListWarning` issues throughout the entire Krill codebase by adding explicit ordering to paginated QuerySets and default ordering to model Meta classes.

### 🔧 Changes Made

#### Views Fixed (4 total):
1. **user_list view** (`krill/person/views.py:670`)
   - Added: `.order_by('user__username')`
2. **sample_search view** (`krill/sample/views/search.py:19`)
   - Added: `.order_by('name')`
3. **aliquot_search view** (`krill/sample/views/search.py:73-78`)
   - Added: `.order_by('sample__name', 'id')`
4. **permission_list view** (`krill/person/views.py:762`)
   - Added: `.order_by('user__username', 'permission_type')`
5. **audit_log view** (`krill/person/views.py:861`)
   - Added: `.order_by('-timestamp')`

#### Models Enhanced (3 total):
1. **UserRole model** (`krill/person/models.py:56`)
   - Added: `ordering = ['user__username']`
2. **Sample model** (`krill/sample/models/sample.py:22-23`)
   - Added: `ordering = ['name']`
3. **Aliquot model** (`krill/sample/models/aliquot.py:48-49`)
   - Added: `ordering = ['sample__name', 'id']`
4. **Permission model** (`krill/person/models.py:188`)
   - Added: `ordering = ['user__username', 'permission_type']`

### ✅ Testing

- ✅ Django system check passes
- ✅ All pagination tests pass without warnings
- ✅ Model default ordering verified
- ✅ No linting errors introduced

### 🎯 Impact

- **Eliminates all UnorderedObjectListWarning instances**
- **Ensures consistent pagination results** across all views
- **Improves user experience** with predictable ordering
- **Follows Django best practices** for QuerySet ordering

### 📋 Ordering Strategy

- **Samples**: Alphabetical by name
- **Aliquots**: By sample name, then by ID
- **Users**: Alphabetical by username
- **Permissions**: By username, then by permission type
- **Audit logs**: Most recent first (timestamp descending)

### 🔗 Related

Fixes #59

### 📝 Notes

This comprehensive fix addresses the root cause of pagination warnings by ensuring all QuerySets have explicit ordering, both at the view level and as model defaults. The ordering choices prioritize user-friendly alphabetical sorting where appropriate, and chronological ordering for audit logs.