### PR TITLE
Fix issue #71: Aliquot search/filtering redirects to sample search

### DIFF
--- a/krill/sample/views/list.py
+++ b/krill/sample/views/list.py
@@ -1,5 +1,6 @@
 from django.views.generic import ListView
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Q
 from ..models.sample import Sample
 from ..models.aliquot import Aliquot, AliquotType, AliquotLocation
 from ..models.source import Source
@@ -34,9 +35,8 @@ class SampleListView(LoginRequiredMixin, ListView):
         if search_query:
             if model_type == 'aliquot':
                 queryset = queryset.filter(
-                    name__icontains=search_query
-                ) | queryset.filter(
-                    sample__name__icontains=search_query
+                    Q(sample__name__icontains=search_query) |
+                    Q(aliquot_type__name__icontains=search_query)
                 )
             elif model_type == 'sample':
                 queryset = queryset.filter(name__icontains=search_query)

--- a/krill/templates/krill/home.html
+++ b/krill/templates/krill/home.html
@@ -88,7 +88,7 @@
                 <span class="material-icons-round">add_circle</span>
                 New Aliquot
             </a>
-            <a href="{% url 'sample:sample_search' %}" class="action-btn">
+            <a href="{% url 'sample:sample_list' %}?type=aliquot" class="action-btn">
                 <span class="material-icons-round">search</span>
                 Find Aliquot
             </a>

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -10,7 +10,10 @@
 
     <!-- Search and Filter Form -->
     <div class="search-form-container">
-        <form id="sampleListForm" class="search-form">
+        <form id="sampleListForm" class="search-form" action="{% url 'sample:sample_list' %}" method="get">
+            {% if request.GET.type %}
+                <input type="hidden" name="type" value="{{ request.GET.type }}">
+            {% endif %}
             <div class="form-row">
                 <div class="form-group">
                     <label for="searchInput">Search</label>
@@ -40,7 +43,7 @@
                 </div>
             </div>
             <div class="form-actions">
-                <button type="button" class="btn btn-primary" onclick="performSearch()">
+                <button type="submit" class="btn btn-primary">
                     <span class="material-icons-round">search</span>
                     Search
                 </button>

--- a/krill/templates/storage/storage.html
+++ b/krill/templates/storage/storage.html
@@ -47,7 +47,7 @@
                 <span class="material-icons-round">add_circle</span>
                 Store New Aliquot
             </a>
-            <a href="{% url 'sample:sample_search' %}" class="action-btn">
+            <a href="{% url 'sample:sample_list' %}?type=aliquot" class="action-btn">
                 <span class="material-icons-round">search</span>
                 Find Aliquot
             </a>


### PR DESCRIPTION
## Description
Fixes issue #71 where aliquot search/filtering was redirecting users back to sample search instead of searching aliquots.

## Changes Made

### Core Fixes
- **Fixed aliquot search query** (`krill/sample/views/list.py`): Changed from using non-existent `name` field to properly searching by `sample__name` and `aliquot_type__name` using Q objects
- **Fixed form submission** (`krill/templates/sample/list.html`): 
  - Added form `action` attribute to ensure proper submission
  - Added hidden `type` field to preserve `type=aliquot` parameter
  - Changed search button from `type="button"` to `type="submit"` so Enter key works correctly

### Navigation Improvements
- **Updated home page** (`krill/templates/krill/home.html`): "Find Aliquot" button now goes to list page with `type=aliquot` filter
- **Updated storage page** (`krill/templates/storage/storage.html`): "Find Aliquot" button now goes to list page with `type=aliquot` filter

## Testing
- ✅ Searching aliquots on the list page now works correctly
- ✅ Pressing Enter in the search box preserves the aliquot filter
- ✅ Clicking the Search button preserves the aliquot filter
- ✅ Navigation links correctly route to aliquot list view

## Related Issue
Closes #71

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes aliquot search to query by sample and type, and updates form/links to target and preserve the aliquot list filter.
> 
> - **Backend**:
>   - **Aliquot search**: In `krill/sample/views/list.py`, use `Q` to filter aliquots by `sample__name` and `aliquot_type__name`.
> - **UI/Templates**:
>   - **Search form** (`krill/templates/sample/list.html`): Add `action` and `method="get"`, include hidden `type` to preserve `type=aliquot`, and make Search button `type="submit"`.
>   - **Navigation**: Update "Find Aliquot" links in `krill/templates/krill/home.html` and `krill/templates/storage/storage.html` to `sample_list?type=aliquot`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 644b30b83bbf69519daeb6a7d120ff2faa2b21b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->