### PR TITLE
Fix issue #79: Storage landing page errors and update test fixtures

### DIFF
--- a/krill/reports/views.py
+++ b/krill/reports/views.py
@@ -99,7 +99,8 @@ def dashboard_stats(request):
 
         # Storage device status
         storage_devices = Device.objects.count()
-        active_devices = Device.objects.filter(is_active=True).count()
+        # Since Device model doesn't have is_active field, all devices are considered active
+        active_devices = storage_devices
 
         # Sample statistics
         total_aliquots = Aliquot.objects.count()
@@ -339,7 +340,8 @@ def storage_dashboard(request):
     try:
         # Device statistics
         total_devices = Device.objects.count()
-        active_devices = Device.objects.filter(is_active=True).count()
+        # Since Device model doesn't have is_active field, all devices are considered active
+        active_devices = total_devices
 
         # Box statistics
         total_boxes = Box.objects.count()
@@ -354,15 +356,21 @@ def storage_dashboard(request):
             total_slots += box.rows * box.columns
         used_slots = AliquotLocation.objects.count()
 
-        # Freezer status (mock data for now)
+        # Freezer status - calculate per device
         freezer_status = []
-        for device in Device.objects.filter(device_type='freezer')[:4]:
+        for device in Device.objects.all()[:4]:
+            # Calculate device-specific capacity
+            device_boxes = Box.objects.filter(rack__shelf__device=device)
+            device_total_slots = sum(box.rows * box.columns for box in device_boxes)
+            device_used_slots = AliquotLocation.objects.filter(box__rack__shelf__device=device).count()
+            device_usage_percent = round((device_used_slots / device_total_slots * 100) if device_total_slots > 0 else 0)
+            
             freezer_status.append({
                 'name': device.name,
-                'temperature': -80.0,  # Mock temperature
+                'temperature': -80.0,  # Mock temperature (could be enhanced with actual temperature tracking)
                 'status': 'operational',
-                'capacity': f"{used_slots}/{total_slots}",
-                'usage_percent': round((used_slots / total_slots * 100) if total_slots > 0 else 0)
+                'capacity': f"{device_used_slots}/{device_total_slots}",
+                'usage_percent': device_usage_percent
             })
 
         stats = {
@@ -373,6 +381,7 @@ def storage_dashboard(request):
             'available_boxes': available_boxes,
             'total_slots': total_slots,
             'used_slots': used_slots,
+            'stored_aliquots': used_slots,  # Alias for JavaScript compatibility
             'freezer_status': freezer_status,
         }
         return JsonResponse(stats)

--- a/tests/fixtures/sample_fixtures.json
+++ b/tests/fixtures/sample_fixtures.json
@@ -74,8 +74,7 @@
     "pk": 1,
     "fields": {
       "name": "Checked Out",
-      "dispositionType": "in_use",
-      "description": ""
+      "disposition_type": "in_use"
     }
   },
   {
@@ -85,10 +84,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": "Thawed by Test Researcher on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -98,10 +98,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": "11-5-19 Test Researcher Checked out"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -109,8 +110,7 @@
     "pk": 2,
     "fields": {
       "name": "In Storage",
-      "dispositionType": "stored",
-      "description": ""
+      "disposition_type": "stored"
     }
   },
   {
@@ -120,10 +120,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -133,10 +134,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -146,10 +148,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -159,10 +162,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+33",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -181,10 +185,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -194,10 +199,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out by Sample Analyst on 09/03/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -205,8 +211,7 @@
     "pk": 3,
     "fields": {
       "name": "Used",
-      "dispositionType": "exhausted",
-      "description": ""
+      "disposition_type": "exhausted"
     }
   },
   {
@@ -216,10 +221,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out by Sample Analyst on 11.28.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -229,10 +235,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -242,10 +249,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out 6.8.23 Test Researcher"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -255,10 +263,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -268,10 +277,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -281,10 +291,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -294,10 +305,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX13",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -307,10 +319,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -320,10 +333,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -333,10 +347,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -346,10 +361,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -359,10 +375,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -372,10 +389,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -385,10 +403,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -398,10 +417,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -411,10 +431,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX20",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -433,10 +454,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -446,10 +468,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -459,10 +482,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -472,10 +496,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -485,10 +510,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -498,10 +524,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX50",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -511,10 +538,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX50",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -524,10 +552,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX50",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -537,10 +566,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX50",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -550,10 +580,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX50",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -572,10 +603,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX55",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -585,10 +617,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX55",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out 6.8.23 Test Researcher"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -598,10 +631,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX55",
-      "experiment": "EXP_VE6P",
-      "notes": "Thawed by Sample Analyst on 09/03/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -611,10 +645,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX55",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -624,10 +659,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX55",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -646,10 +682,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX60",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -659,10 +696,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX60",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -672,10 +710,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX60",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -685,10 +724,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX60",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -698,10 +738,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX60",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out by Sample Analyst on 11.28.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -711,10 +752,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out bu Sample Analyst on 11.28.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -724,10 +766,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -737,10 +780,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -750,10 +794,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -763,10 +808,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -776,10 +822,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -789,10 +836,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX7",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -811,10 +859,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX45",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -824,10 +873,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX45",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -837,10 +887,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX45",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -850,10 +901,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX45",
-      "experiment": "EXP_VE6P",
-      "notes": "Checked out by Sample Analyst on 11.28.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -863,10 +915,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX45",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -885,10 +938,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -898,10 +952,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -911,10 +966,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -924,10 +980,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -937,10 +994,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -950,10 +1008,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -963,10 +1022,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -976,10 +1036,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 03/06/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -989,10 +1050,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 03/08/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1002,10 +1064,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1015,10 +1078,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1028,10 +1092,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": "Checkout by Test Operator on 6/5/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1041,10 +1106,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1054,10 +1120,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1067,10 +1134,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+36",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1089,10 +1157,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Checked out by Test Analyst on 11/15/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1102,10 +1171,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Checkout out by Test Analyst on 2/4/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1115,10 +1185,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Thawed by Test Analyst on 2/6/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1128,10 +1199,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Checked out by Sample Analyst on 01/17/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1141,10 +1213,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Thawed by Test Operator on 2-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1154,10 +1227,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 03/06/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1167,10 +1241,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 03/08/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1180,10 +1255,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p77",
-      "experiment": "",
-      "notes": "Thawed by Test Operator on 9-24-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1204,10 +1280,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX52",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1217,10 +1294,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX52",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1230,10 +1308,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX52",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1243,10 +1322,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX52",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1256,10 +1336,11 @@
       "parent": null,
       "sample": 2,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX52",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1277,10 +1358,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1290,10 +1372,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1303,10 +1386,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1316,10 +1400,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1329,10 +1414,11 @@
       "parent": null,
       "sample": 3,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1342,10 +1428,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX57",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1355,10 +1442,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX57",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1368,10 +1456,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX57",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1381,10 +1470,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX57",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1394,10 +1484,11 @@
       "parent": null,
       "sample": 4,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX57",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1407,10 +1498,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX62",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1420,10 +1512,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX62",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1433,10 +1526,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX62",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1446,10 +1540,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX62",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1459,10 +1554,11 @@
       "parent": null,
       "sample": 5,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX62",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1472,10 +1568,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1485,10 +1582,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1498,10 +1596,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1511,10 +1610,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1524,10 +1624,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1537,10 +1638,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1550,10 +1652,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p84",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1563,10 +1666,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1576,10 +1680,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1589,10 +1694,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1602,10 +1708,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1615,10 +1722,11 @@
       "parent": null,
       "sample": 6,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX47",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1628,10 +1736,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1641,10 +1750,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1654,10 +1764,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1667,10 +1778,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1680,10 +1792,11 @@
       "parent": null,
       "sample": 7,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX49",
-      "experiment": "EXP_VE6P",
-      "notes": "Shipped to Test Researcher/Test Researcher on 4/30/19 by Test Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1702,10 +1815,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1715,10 +1829,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1728,10 +1843,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1741,10 +1857,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1754,10 +1871,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1767,10 +1885,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1780,10 +1899,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1793,10 +1913,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1806,10 +1927,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p148",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1819,10 +1941,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1832,10 +1955,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1845,10 +1969,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1858,10 +1983,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1871,10 +1997,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1884,10 +2011,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p86",
-      "experiment": "",
-      "notes": "Checked out by Test Analyst on 5/30/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1914,10 +2042,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1927,10 +2056,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1940,10 +2070,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1953,10 +2084,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1966,10 +2098,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -1979,10 +2112,11 @@
       "parent": null,
       "sample": 10,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2001,10 +2135,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p18",
-      "experiment": "",
-      "notes": "*CELL_UPVR-MAnon Operator found to be only 93% fingerprinting match to ATCC line, aliqouts were disposed of and future experiments with CELL_UPVR cell were performed with CELL_UPVR cell line from Virshup/Singapore."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2014,10 +2149,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p18",
-      "experiment": "",
-      "notes": "*CELL_UPVR-MAnon Operator found to be only 93% fingerprinting match to ATCC line, aliqouts were disposed of and future experiments with CELL_UPVR cell were performed with CELL_UPVR cell line from Virshup/Singapore."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2027,10 +2163,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p18",
-      "experiment": "",
-      "notes": "*CELL_UPVR-MAnon Operator found to be only 93% fingerprinting match to ATCC line, aliqouts were disposed of and future experiments with CELL_UPVR cell were performed with CELL_UPVR cell line from Virshup/Singapore."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2040,10 +2177,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p18",
-      "experiment": "",
-      "notes": "*CELL_UPVR-MAnon Operator found to be only 93% fingerprinting match to ATCC line, aliqouts were disposed of and future experiments with CELL_UPVR cell were performed with CELL_UPVR cell line from Virshup/Singapore."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2053,10 +2191,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2075,10 +2214,11 @@
       "parent": null,
       "sample": 12,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX6",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2088,10 +2228,11 @@
       "parent": null,
       "sample": 12,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX6",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2101,10 +2242,11 @@
       "parent": null,
       "sample": 12,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX6",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2114,10 +2256,11 @@
       "parent": null,
       "sample": 12,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX6",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2127,10 +2270,11 @@
       "parent": null,
       "sample": 12,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX6",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2140,10 +2284,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2153,10 +2298,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2166,10 +2312,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2179,10 +2326,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2192,10 +2340,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2205,10 +2354,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": "Thawed by Test Operator on 4-22-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2218,10 +2368,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 10.16.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2231,10 +2382,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": "Thawed by Demo Researcher on 7/2/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2244,10 +2396,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p143",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2268,10 +2421,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2281,10 +2435,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2294,10 +2449,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2307,10 +2463,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2320,10 +2477,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2333,10 +2491,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2346,10 +2505,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2359,10 +2519,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2372,10 +2533,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2431,10 +2593,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "EXP_R2LI",
-      "notes": "these are probably contaminated"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2444,10 +2607,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2457,10 +2621,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2470,10 +2635,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2483,10 +2649,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2496,10 +2663,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2509,10 +2677,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2522,10 +2691,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "EXP_R2LI",
-      "notes": "dfgretreatsgsergrgreg"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2535,10 +2705,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2548,10 +2719,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2561,10 +2733,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2574,10 +2747,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2587,10 +2761,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2600,10 +2775,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "EXP_R2LI",
-      "notes": "testetstetsetetestesteststeestset"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2622,10 +2798,11 @@
       "parent": null,
       "sample": 14,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2635,10 +2812,11 @@
       "parent": null,
       "sample": 14,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2648,10 +2826,11 @@
       "parent": null,
       "sample": 14,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2661,10 +2840,11 @@
       "parent": null,
       "sample": 14,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2674,10 +2854,11 @@
       "parent": null,
       "sample": 14,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_2G9O",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2696,10 +2877,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2709,10 +2891,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2722,10 +2905,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2735,10 +2919,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2748,10 +2933,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2778,10 +2964,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p21",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2791,10 +2978,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p21",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2804,10 +2992,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p21",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2826,10 +3015,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+8",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2839,10 +3029,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+8",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 5/10/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2852,10 +3043,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Analyst on 6/28/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2865,10 +3057,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+8",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2878,10 +3071,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2891,10 +3085,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2904,10 +3099,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2917,10 +3113,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2930,10 +3127,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2960,10 +3158,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2982,10 +3181,11 @@
       "parent": null,
       "sample": 19,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -2995,10 +3195,11 @@
       "parent": null,
       "sample": 19,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3008,10 +3209,11 @@
       "parent": null,
       "sample": 19,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3021,10 +3223,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "EXP_R2LI",
-      "notes": "these are probably contaminated"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3034,10 +3237,11 @@
       "parent": null,
       "sample": 13,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "EXP_R2LI",
-      "notes": "these are probably contaminated"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3047,10 +3251,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3060,10 +3265,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3082,10 +3288,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3095,10 +3302,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3108,10 +3316,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX2",
-      "experiment": "EXP_DIB4",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3121,10 +3330,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p27",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 08/15/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3134,10 +3344,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p27",
-      "experiment": "",
-      "notes": "Thawed by Demo Researcher on 7/2/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3147,10 +3358,11 @@
       "parent": null,
       "sample": 16,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p27",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3160,10 +3372,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": "Frozen 7/13/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3173,10 +3386,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": "Frozen 7/13/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3186,10 +3400,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": "Frozen 7/13/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3199,10 +3414,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": "Frozen 7/13/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3212,10 +3428,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p145",
-      "experiment": "",
-      "notes": "Frozen 7/13/17"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3225,10 +3442,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3238,10 +3456,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3251,10 +3470,11 @@
       "parent": null,
       "sample": 18,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3264,10 +3484,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3277,10 +3498,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3290,10 +3512,11 @@
       "parent": null,
       "sample": 20,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "pX5",
-      "experiment": "EXP_5LKC",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3320,10 +3543,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3333,10 +3557,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3355,10 +3580,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P8",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3368,10 +3594,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3381,10 +3608,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3394,10 +3622,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3407,10 +3636,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3420,10 +3650,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3433,10 +3664,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3446,10 +3678,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3459,10 +3692,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3472,10 +3706,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3485,10 +3720,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3498,10 +3734,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3511,10 +3748,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3524,10 +3762,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3537,10 +3776,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3550,10 +3790,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3563,10 +3804,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3576,10 +3818,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3589,10 +3832,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3602,10 +3846,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3615,10 +3860,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3628,10 +3874,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3641,10 +3888,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3654,10 +3902,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3678,10 +3927,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3691,10 +3941,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3704,10 +3955,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3717,10 +3969,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3730,10 +3983,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3743,10 +3997,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3756,10 +4011,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3769,10 +4025,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3782,10 +4039,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3795,10 +4053,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3808,10 +4067,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3821,10 +4081,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3834,10 +4095,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3847,10 +4109,11 @@
       "parent": null,
       "sample": 22,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "P7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3869,10 +4132,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3882,10 +4146,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3904,10 +4169,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3917,10 +4183,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3939,10 +4206,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3952,10 +4220,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3974,10 +4243,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -3987,10 +4257,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "EXP_W21B",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4009,10 +4280,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4022,10 +4294,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4035,10 +4308,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4048,10 +4322,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by Sample Analyst on 04/11/19 for growup and freezeback"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4061,10 +4336,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4074,10 +4350,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by Demo Researcher on 11-5-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4087,10 +4364,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by Sample Analyst on 11.01.18. ***Cells did not thaw well***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4100,10 +4378,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst on 10-22-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4113,10 +4392,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst on 9-10-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4126,10 +4406,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 6/4/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4139,10 +4420,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4152,10 +4434,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4165,10 +4448,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4178,10 +4462,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4191,10 +4476,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4204,10 +4490,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "22",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4217,10 +4504,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4230,10 +4518,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4243,10 +4532,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4256,10 +4546,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4269,10 +4560,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4282,10 +4574,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4295,10 +4588,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4308,10 +4602,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4321,10 +4616,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4334,10 +4630,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4347,10 +4644,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4360,10 +4658,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4373,10 +4672,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4386,10 +4686,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4399,10 +4700,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4412,10 +4714,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4425,10 +4728,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4438,10 +4742,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4451,10 +4756,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4464,10 +4770,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4477,10 +4784,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4490,10 +4798,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4503,10 +4812,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4516,10 +4826,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4538,10 +4849,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4551,10 +4863,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4564,10 +4877,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Analyst to check viability. Cells were fine and an aliquote was frozen to replace it (11/16/17 P49)."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4586,10 +4900,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4599,10 +4914,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4612,10 +4928,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4634,10 +4951,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4647,10 +4965,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4660,10 +4979,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "48",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4673,10 +4993,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4686,10 +5007,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4699,10 +5021,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4712,10 +5035,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "51",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4725,10 +5049,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "51",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4738,10 +5063,11 @@
       "parent": null,
       "sample": 29,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "51",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4751,10 +5077,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4764,10 +5091,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4777,10 +5105,11 @@
       "parent": null,
       "sample": 30,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "50",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4790,10 +5119,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 03/28/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4814,10 +5144,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4827,10 +5158,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4840,10 +5172,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4862,10 +5195,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4875,10 +5209,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Researcher 7.20.22"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4888,10 +5223,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4901,10 +5237,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4914,10 +5251,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 5/10/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4927,10 +5265,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst on 1-2-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4940,10 +5279,11 @@
       "parent": null,
       "sample": 31,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+7",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4953,10 +5293,11 @@
       "parent": null,
       "sample": 28,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "49",
-      "experiment": "",
-      "notes": "This aliquote replaces the previous MCF7 AM #1 aliquote that was thawed for cell viability."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4983,10 +5324,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -4996,10 +5338,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5009,10 +5352,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5022,10 +5366,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5035,10 +5380,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5048,10 +5394,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Check out by CELL_0XXZ Operator on 2-15-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5072,10 +5419,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5085,10 +5433,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5098,10 +5447,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5111,10 +5461,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5124,10 +5475,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5137,10 +5489,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5150,10 +5503,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-16-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5163,10 +5517,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 4-11-19. COMBINED WITH 1-3 aliquot. *CONTAMINATED AFTER THAW*"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5176,10 +5531,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-11-19. *CONTAMINATED AFTER THAW*"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5189,10 +5545,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 2-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5202,10 +5559,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 12-11-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5215,10 +5573,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "69",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 5/30/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5228,10 +5587,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "24",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5241,10 +5601,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5254,10 +5615,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5267,10 +5629,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5280,10 +5643,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5293,10 +5657,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5306,10 +5671,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5319,10 +5685,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5332,10 +5699,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5345,10 +5713,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5358,10 +5727,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5388,10 +5758,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5401,10 +5772,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst the week of 9-17-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5414,10 +5786,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Analyst on 1-2-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5427,10 +5800,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5440,10 +5814,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": "Checked out by Sample Analyst on 06.03.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5464,10 +5839,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5477,10 +5853,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5490,10 +5867,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5503,10 +5881,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5516,10 +5895,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5529,10 +5909,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5542,10 +5923,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5555,10 +5937,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5568,10 +5951,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5581,10 +5965,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5594,10 +5979,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5607,10 +5993,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5620,10 +6007,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5633,10 +6021,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5646,10 +6035,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5659,10 +6049,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5672,10 +6063,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5685,10 +6077,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5698,10 +6091,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5711,10 +6105,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5724,10 +6119,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5737,10 +6133,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5750,10 +6147,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5763,10 +6161,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5776,10 +6175,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5789,10 +6189,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5802,10 +6203,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5815,10 +6217,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5828,10 +6231,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5841,10 +6245,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5854,10 +6259,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5867,10 +6273,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5880,10 +6287,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5893,10 +6301,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5906,10 +6315,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5919,10 +6329,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5932,10 +6343,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5945,10 +6357,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5958,10 +6371,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5971,10 +6385,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5984,10 +6399,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -5997,10 +6413,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6010,10 +6427,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6023,10 +6441,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6036,10 +6455,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6049,10 +6469,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6062,10 +6483,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6075,10 +6497,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6088,10 +6511,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6101,10 +6525,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6114,10 +6539,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6127,10 +6553,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6140,10 +6567,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6153,10 +6581,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6166,10 +6595,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6179,10 +6609,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6192,10 +6623,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6205,10 +6637,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6218,10 +6651,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6231,10 +6665,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6244,10 +6679,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6257,10 +6693,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6270,10 +6707,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6283,10 +6721,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6296,10 +6735,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6309,10 +6749,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6322,10 +6763,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6335,10 +6777,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6348,10 +6791,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6361,10 +6805,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6374,10 +6819,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6387,10 +6833,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6400,10 +6847,11 @@
       "parent": null,
       "sample": 33,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "unknown",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 8/31/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6413,10 +6861,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": "Checked out on 4/12/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6426,10 +6875,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6439,10 +6889,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6452,10 +6903,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 6/27/19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6465,10 +6917,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 11-14-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6478,10 +6931,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "23",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 7/9/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6491,10 +6945,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6504,10 +6959,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6517,10 +6973,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6530,10 +6987,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6543,10 +7001,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed by CELL_0XXZ Operator on 10-22-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6556,10 +7015,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6569,10 +7029,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6582,10 +7043,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed by CELL_0XXZ Operator on 10-22-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6595,10 +7057,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6608,10 +7071,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6621,10 +7085,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed on 10-22-18 by CELL_0XXZ Operator."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6634,10 +7099,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6647,10 +7113,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6660,10 +7127,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6673,10 +7141,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "7",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6686,10 +7155,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Checked out by CELL_0XXZ Operator on 4-15-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6699,10 +7169,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6712,10 +7183,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6734,10 +7206,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6747,10 +7220,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-15-19. ***CONTAMINATED AFTER THAW***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6760,10 +7234,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-11-19. ***CONTAMINATED AFTER THAW***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6773,10 +7248,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 2-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6786,10 +7262,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 12-11-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6799,10 +7276,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Checkout by CELL_0XXZ Operator on 5/30/18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6821,10 +7299,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6834,10 +7313,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-15-19. ***CONTAMINATED AFTER THAW***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6847,10 +7327,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 4-11-19. ***CONTAMINATED AFTER THAW***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6860,10 +7341,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 2-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6873,10 +7355,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 12-11-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6886,10 +7369,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Checked out by CELL_0XXZ Operator on 5/30/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6899,10 +7383,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 2-2-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6912,10 +7397,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Freeze back on 2-2-18 from previous thaw. Thawed by CELL_0XXZ Operator on 10-22-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6936,10 +7422,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Froze back on 5/11/18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6949,10 +7436,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Froze back on 5/11/18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6962,10 +7450,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Froze back on 5/11/18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6975,10 +7464,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Froze back on 5/11/18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -6988,10 +7478,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Froze back on 5/11/18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7001,10 +7492,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7014,10 +7506,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7027,10 +7520,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7040,10 +7534,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw. Thawed by CELL_0XXZ Operator on 4-9-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7053,10 +7548,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7066,10 +7562,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7079,10 +7576,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7092,10 +7590,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7105,10 +7604,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7118,10 +7618,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7131,10 +7632,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7144,10 +7646,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7157,10 +7660,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7170,10 +7674,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7183,10 +7688,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw. Checked out by CELL_0XXZ Operator on 4-9-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7196,10 +7702,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7209,10 +7716,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7222,10 +7730,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7235,10 +7744,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7248,10 +7758,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7261,10 +7772,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7274,10 +7786,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7287,10 +7800,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7300,10 +7814,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7313,10 +7828,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Freeze back on 5-11-18 from previous thaw. Checked out by CELL_0XXZ Operator on 4-9-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7335,10 +7851,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "1",
-      "experiment": "",
-      "notes": "Original vial from ATCC."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7348,10 +7865,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7370,10 +7888,11 @@
       "parent": null,
       "sample": 37,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7383,10 +7902,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Researcher on 09/04/19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7396,10 +7916,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7409,10 +7930,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7422,10 +7944,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7435,10 +7958,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7448,10 +7972,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7461,10 +7986,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7474,10 +8000,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7487,10 +8014,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "11-5-2019 CELL_0XXZ Researcher Checked out"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7500,10 +8028,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "17",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Researcher on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7513,10 +8042,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7526,10 +8056,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7539,10 +8070,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7552,10 +8084,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7582,10 +8115,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7595,10 +8129,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7608,10 +8143,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7621,10 +8157,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7634,10 +8171,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7656,10 +8194,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7669,10 +8208,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7682,10 +8222,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7695,10 +8236,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7708,10 +8250,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 9-24-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7730,10 +8273,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7743,10 +8287,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7756,10 +8301,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": "Thawd by CELL_0XXZ Operator on 2-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7769,10 +8315,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Analyst on 11-7-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7782,10 +8329,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "13",
-      "experiment": "",
-      "notes": "Thawed by CELL_0XXZ Operator on 9-24-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7804,10 +8352,11 @@
       "parent": null,
       "sample": 41,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7817,10 +8366,11 @@
       "parent": null,
       "sample": 41,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7830,10 +8380,11 @@
       "parent": null,
       "sample": 41,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7843,10 +8394,11 @@
       "parent": null,
       "sample": 41,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7856,10 +8408,11 @@
       "parent": null,
       "sample": 41,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7878,10 +8431,11 @@
       "parent": null,
       "sample": 42,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7891,10 +8445,11 @@
       "parent": null,
       "sample": 42,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7904,10 +8459,11 @@
       "parent": null,
       "sample": 42,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7917,10 +8473,11 @@
       "parent": null,
       "sample": 42,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7930,10 +8487,11 @@
       "parent": null,
       "sample": 42,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7943,10 +8501,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7956,10 +8515,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7969,10 +8529,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7982,10 +8543,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -7995,10 +8557,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8008,10 +8571,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8021,10 +8585,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8034,10 +8599,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8058,10 +8624,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "145",
-      "experiment": "",
-      "notes": "Frozen back on 07.11.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8071,10 +8638,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "145",
-      "experiment": "",
-      "notes": "Frozen back on 07.11.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8084,10 +8652,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "145",
-      "experiment": "",
-      "notes": "Frozen back on 07.11.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8097,10 +8666,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "145",
-      "experiment": "",
-      "notes": "Frozen back on 07.11.18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8110,10 +8680,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "145",
-      "experiment": "",
-      "notes": "Frozen back on 07.11.18 Thawed by Sample Analyst on 11.01.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8123,10 +8694,11 @@
       "parent": null,
       "sample": 37,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p3",
-      "experiment": "",
-      "notes": "7/27/2018"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8136,10 +8708,11 @@
       "parent": null,
       "sample": 37,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p3",
-      "experiment": "",
-      "notes": "7/27/2018"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8149,10 +8722,11 @@
       "parent": null,
       "sample": 37,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p3",
-      "experiment": "",
-      "notes": "7/27/2018"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8162,10 +8736,11 @@
       "parent": null,
       "sample": 37,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p3",
-      "experiment": "",
-      "notes": "7/27/2018"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8175,10 +8750,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "47",
-      "experiment": "",
-      "notes": "Freezeback from flask previously provided by CELL_0XXZ Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8188,10 +8764,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "47",
-      "experiment": "",
-      "notes": "Freezeback from flask previously provided by CELL_0XXZ Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8210,10 +8787,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8223,10 +8801,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8236,10 +8815,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8249,10 +8829,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8271,10 +8852,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8284,10 +8866,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8297,10 +8880,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p+2",
-      "experiment": "EXP_QQL9",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8321,10 +8905,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8334,10 +8919,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8347,10 +8933,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8360,10 +8947,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8373,10 +8961,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18. Checked out by CELL_0XXZ Operator on 10-18-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8386,10 +8975,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8399,10 +8989,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8412,10 +9003,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8425,10 +9017,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8438,10 +9031,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18. Checked out by CELL_0XXZ Operator on 10-18-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8451,10 +9045,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8464,10 +9059,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8477,10 +9073,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8490,10 +9087,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 8-23-18. Checked out by CELL_0XXZ Operator on 10-18-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8519,10 +9117,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 2,
-      "passage": "0",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 2,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8532,10 +9131,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "?",
-      "experiment": "",
-      "notes": "Thawed by Sample Analyst on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8545,10 +9145,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Check out by Sample Analyst on 07.23.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8558,10 +9159,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Aliquotes frozen back on 08.28.18 by Sample AnalystThawed 01/02/18 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8571,10 +9173,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Aliquotes frozen back on 08.28.18 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8584,10 +9187,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Aliquotes frozen back on 08.28.18 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8597,10 +9201,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Aliquotes frozen back on 08.28.18 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8610,10 +9215,11 @@
       "parent": null,
       "sample": 17,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Aliquotes frozen back on 08.28.18 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8632,10 +9238,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8645,10 +9252,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8658,10 +9266,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8671,10 +9280,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8684,10 +9294,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8697,10 +9308,11 @@
       "parent": null,
       "sample": 45,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_7GP1",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8719,10 +9331,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8732,10 +9345,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8745,10 +9359,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8758,10 +9373,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8771,10 +9387,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8784,10 +9401,11 @@
       "parent": null,
       "sample": 46,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_UJF6",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8797,10 +9415,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8810,10 +9429,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8823,10 +9443,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8836,10 +9457,11 @@
       "parent": null,
       "sample": 36,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8858,10 +9480,11 @@
       "parent": null,
       "sample": 47,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8871,10 +9494,11 @@
       "parent": null,
       "sample": 47,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8884,10 +9508,11 @@
       "parent": null,
       "sample": 47,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8897,10 +9522,11 @@
       "parent": null,
       "sample": 47,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8919,10 +9545,11 @@
       "parent": null,
       "sample": 48,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8932,10 +9559,11 @@
       "parent": null,
       "sample": 48,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8945,10 +9573,11 @@
       "parent": null,
       "sample": 48,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8958,10 +9587,11 @@
       "parent": null,
       "sample": 48,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": "Frozen back by MAnon Operator on 8-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8980,10 +9610,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -8993,10 +9624,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9006,10 +9638,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9028,10 +9661,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9041,10 +9675,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9054,10 +9689,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9076,10 +9712,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9089,10 +9726,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9102,10 +9740,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9124,10 +9763,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9137,10 +9777,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9150,10 +9791,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "EXP_PX66",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9163,10 +9805,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "82",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9176,10 +9819,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "82",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9189,10 +9833,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "82",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9202,10 +9847,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "82",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18. Thawed by CELL_0XXZ Operator on 4-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9215,10 +9861,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9228,10 +9875,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9241,10 +9889,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9254,10 +9903,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18. Thawed by CELL_0XXZ Operator on 4-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9267,10 +9917,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9280,10 +9931,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9293,10 +9945,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9306,10 +9959,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "18",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-25-18. Thawed by CELL_0XXZ Operator on 4-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9319,10 +9973,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "14",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9332,10 +9987,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "14",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9345,10 +10001,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "14",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9358,10 +10015,11 @@
       "parent": null,
       "sample": 38,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "14",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18. Checked out by CELL_0XXZ Operator on 3-4-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9371,10 +10029,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9384,10 +10043,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9397,10 +10057,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9410,10 +10071,11 @@
       "parent": null,
       "sample": 43,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18. Checked out by CELL_0XXZ Operator on 3-4-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9423,10 +10085,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9436,10 +10099,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9449,10 +10113,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9462,10 +10127,11 @@
       "parent": null,
       "sample": 44,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "9",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 10-23-18. Checked out by CELL_0XXZ Operator on 3-4-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9475,10 +10141,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9488,10 +10155,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9501,10 +10169,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9514,10 +10183,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9527,10 +10197,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9540,10 +10211,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9553,10 +10225,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9566,10 +10239,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the original cell line that Anon Technician created. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9579,10 +10253,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9592,10 +10267,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9605,10 +10281,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9618,10 +10295,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9631,10 +10309,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9644,10 +10323,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9657,10 +10337,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9670,10 +10351,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "EXP_PX66",
-      "notes": "These are a second, later freezeback of the origianl cell line that Anon Technician created. Thawed by CELL_0XXZ Operator on 1-14-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9683,10 +10365,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9696,10 +10379,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9709,10 +10393,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9722,10 +10407,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9735,10 +10421,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from origianl cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9748,10 +10435,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from origianl cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9761,10 +10449,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from origianl cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9774,10 +10463,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from origianl cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9787,10 +10477,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cel lline Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9800,10 +10491,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cel lline Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9813,10 +10505,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cel lline Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9826,10 +10519,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "11",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cel lline Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9839,10 +10533,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9852,10 +10547,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9865,10 +10561,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9878,10 +10575,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "EXP_PX66",
-      "notes": "Later passage from original cell line Anon Technician created."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9899,10 +10597,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "84",
-      "experiment": "",
-      "notes": "Cells frozen back by HS from Dr. Riggins lab. We recieved these on 12/4/18."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9923,10 +10622,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Freeze-back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9936,10 +10636,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Freeze-back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9949,10 +10650,11 @@
       "parent": null,
       "sample": 11,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Freeze-back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9962,10 +10664,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9975,10 +10678,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Checked out by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -9988,10 +10692,11 @@
       "parent": null,
       "sample": 21,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10001,10 +10706,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10014,10 +10720,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Checked out by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10027,10 +10734,11 @@
       "parent": null,
       "sample": 24,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10040,10 +10748,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10053,10 +10762,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19. Checked out by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10066,10 +10776,11 @@
       "parent": null,
       "sample": 23,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10079,10 +10790,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10092,10 +10804,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19. Checked out by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10105,10 +10818,11 @@
       "parent": null,
       "sample": 26,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10118,10 +10832,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10131,10 +10846,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Checked out by CELL_0XXZ Operator on 6-21-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10144,10 +10860,11 @@
       "parent": null,
       "sample": 25,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10157,10 +10874,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10170,10 +10888,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10183,10 +10902,11 @@
       "parent": null,
       "sample": 49,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10196,10 +10916,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10209,10 +10930,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10222,10 +10944,11 @@
       "parent": null,
       "sample": 50,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10235,10 +10958,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10248,10 +10972,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10261,10 +10986,11 @@
       "parent": null,
       "sample": 51,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10274,10 +11000,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10287,10 +11014,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10300,10 +11028,11 @@
       "parent": null,
       "sample": 52,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "EXP_PX66",
-      "notes": "Frozen back from a previous thaw on 1-18-19. Thawed by CELL_0XXZ Operator on 2-11-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10338,10 +11067,11 @@
       "parent": null,
       "sample": 53,
       "quantity": 0,
-      "aliquotType": 3,
-      "passage": "P3.C1.M2",
-      "experiment": "",
-      "notes": "Recived from Anon Analyst Strutz on 2/20/19. The material is listed as \"viable chunks\"."
+      "aliquot_type": 3,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10351,10 +11081,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "38",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10364,10 +11095,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "38",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10377,10 +11109,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "38",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10390,10 +11123,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "38",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10403,10 +11137,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "38",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10416,10 +11151,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "78",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10429,10 +11165,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "78",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10442,10 +11179,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "79",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst on 4-4-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10455,10 +11193,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "40",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst on 04.04.19 Thawed by Sample Analyst on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10468,10 +11207,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "40",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst on 04.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10481,10 +11221,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "40",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst on 04.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10494,10 +11235,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "79",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst 4-4-19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10507,10 +11249,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "79",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst 4-4-19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10520,10 +11263,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "49",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst 04.04.19 Thawed by Sample Analyst on 09.04.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10533,10 +11277,11 @@
       "parent": null,
       "sample": 15,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "8",
-      "experiment": "",
-      "notes": "Frozen back by Sample Analyst 04.04.19 Checked out on 04.29.19"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10546,10 +11291,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10559,10 +11305,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10572,10 +11319,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10585,10 +11333,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10598,10 +11347,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10611,10 +11361,11 @@
       "parent": null,
       "sample": 8,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "85",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10624,10 +11375,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10637,10 +11389,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10650,10 +11403,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10663,10 +11417,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10676,10 +11431,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10689,10 +11445,11 @@
       "parent": null,
       "sample": 39,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10702,10 +11459,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10715,10 +11473,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10728,10 +11487,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10741,10 +11501,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10754,10 +11515,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10767,10 +11529,11 @@
       "parent": null,
       "sample": 40,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "21",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-26-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10780,10 +11543,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10793,10 +11557,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10806,10 +11571,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10819,10 +11585,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10832,10 +11599,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10845,10 +11613,11 @@
       "parent": null,
       "sample": 9,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "146",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 4-30-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10858,10 +11627,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10871,10 +11641,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10884,10 +11655,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10897,10 +11669,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10910,10 +11683,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10923,10 +11697,11 @@
       "parent": null,
       "sample": 1,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "10",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10936,10 +11711,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!!!! They are labeled as WNT4 but are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10949,10 +11725,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! They are labeled as WNT4 but are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10962,10 +11739,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! They are labelled at WNT4 but are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10975,10 +11753,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! They are labelled as WNT4 bu are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -10988,10 +11767,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! They are labelled as WNT4 but are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11001,10 +11781,11 @@
       "parent": null,
       "sample": 34,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! The are labelled as WNT4 but are actually WNT3A***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11014,10 +11795,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! Labelled as WNT3A but are actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11027,10 +11809,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! Labelled as WNT3A but are actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11040,10 +11823,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! Labelled as WNT3A but are actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11053,10 +11837,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly! Labelled as WNT3A but are actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11066,10 +11851,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled incorrectly!!! Labelled as WNT3A but actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11079,10 +11865,11 @@
       "parent": null,
       "sample": 35,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "12",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 5-6-19. ***Labelled inicorrectly!!! Labelled as WNT3A but actually WNT4***"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11092,10 +11879,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11105,10 +11893,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11118,10 +11907,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11131,10 +11921,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11144,10 +11935,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11157,10 +11949,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Freezebacks created by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11170,10 +11963,11 @@
       "parent": null,
       "sample": 27,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "p19",
-      "experiment": "",
-      "notes": "Thawed 05/14/19 by Sample Analyst"
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11183,10 +11977,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "26",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 7/6/19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11196,10 +11991,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "26",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 7/6/19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11209,10 +12005,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "26",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 7/6/19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11222,10 +12019,11 @@
       "parent": null,
       "sample": 32,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "26",
-      "experiment": "",
-      "notes": "Frozen back by CELL_0XXZ Operator on 7/6/19."
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11263,10 +12061,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11276,10 +12075,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11289,10 +12089,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11302,10 +12103,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "1",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11326,10 +12128,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11339,10 +12142,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11352,10 +12156,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11365,10 +12170,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "4",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11378,10 +12184,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11391,10 +12198,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11404,10 +12212,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11417,10 +12226,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11430,10 +12240,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11443,10 +12254,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11456,10 +12268,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11469,10 +12282,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11482,10 +12296,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11495,10 +12310,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11508,10 +12324,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "5",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11521,10 +12338,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11534,10 +12352,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11547,10 +12366,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11560,10 +12380,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11573,10 +12394,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11586,10 +12408,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11599,10 +12422,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11612,10 +12436,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11625,10 +12450,11 @@
       "parent": null,
       "sample": 54,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "6",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11658,10 +12484,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11671,10 +12498,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11684,10 +12512,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11697,10 +12526,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11710,10 +12540,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11723,10 +12554,11 @@
       "parent": null,
       "sample": 55,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "16",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11753,10 +12585,11 @@
       "parent": null,
       "sample": 56,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11766,10 +12599,11 @@
       "parent": null,
       "sample": 56,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11779,10 +12613,11 @@
       "parent": null,
       "sample": 56,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11801,10 +12636,11 @@
       "parent": null,
       "sample": 57,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11814,10 +12650,11 @@
       "parent": null,
       "sample": 57,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11827,10 +12664,11 @@
       "parent": null,
       "sample": 57,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11849,10 +12687,11 @@
       "parent": null,
       "sample": 58,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11862,10 +12701,11 @@
       "parent": null,
       "sample": 58,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11875,10 +12715,11 @@
       "parent": null,
       "sample": 58,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11897,10 +12738,11 @@
       "parent": null,
       "sample": 59,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11910,10 +12752,11 @@
       "parent": null,
       "sample": 59,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11923,10 +12766,11 @@
       "parent": null,
       "sample": 59,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11945,10 +12789,11 @@
       "parent": null,
       "sample": 60,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11958,10 +12803,11 @@
       "parent": null,
       "sample": 60,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11971,10 +12817,11 @@
       "parent": null,
       "sample": 60,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -11993,10 +12840,11 @@
       "parent": null,
       "sample": 61,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12006,10 +12854,11 @@
       "parent": null,
       "sample": 61,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12019,10 +12868,11 @@
       "parent": null,
       "sample": 61,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "2",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12041,10 +12891,11 @@
       "parent": null,
       "sample": 62,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12054,10 +12905,11 @@
       "parent": null,
       "sample": 62,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12067,10 +12919,11 @@
       "parent": null,
       "sample": 62,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12089,10 +12942,11 @@
       "parent": null,
       "sample": 63,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12102,10 +12956,11 @@
       "parent": null,
       "sample": 63,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12115,10 +12970,11 @@
       "parent": null,
       "sample": 63,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12137,10 +12993,11 @@
       "parent": null,
       "sample": 64,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12150,10 +13007,11 @@
       "parent": null,
       "sample": 64,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12163,10 +13021,11 @@
       "parent": null,
       "sample": 64,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12185,10 +13044,11 @@
       "parent": null,
       "sample": 65,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12198,10 +13058,11 @@
       "parent": null,
       "sample": 65,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12211,10 +13072,11 @@
       "parent": null,
       "sample": 65,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12233,10 +13095,11 @@
       "parent": null,
       "sample": 66,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12246,10 +13109,11 @@
       "parent": null,
       "sample": 66,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12259,10 +13123,11 @@
       "parent": null,
       "sample": 66,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12281,10 +13146,11 @@
       "parent": null,
       "sample": 67,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12294,10 +13160,11 @@
       "parent": null,
       "sample": 67,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   },
   {
@@ -12307,10 +13174,11 @@
       "parent": null,
       "sample": 67,
       "quantity": 0,
-      "aliquotType": 1,
-      "passage": "3",
-      "experiment": "",
-      "notes": ""
+      "aliquot_type": 1,
+      "created_at": "2025-12-15T20:07:05.710388",
+      "updated_at": "2025-12-15T20:07:05.710388",
+      "access_level": "all_members",
+      "deleted": false
     }
   }
 ]


### PR DESCRIPTION
## Description

This PR fixes issue #79 where the storage landing page was showing errors for all fields when loading. It also updates the test fixtures to match the current database schema.

## Changes

### Storage Landing Page Fixes
- Fixed `storage_dashboard` view to return `stored_aliquots` field expected by JavaScript
- Removed references to non-existent Device model fields (`is_active`, `device_type`)
- Improved freezer status calculation to show per-device capacity and usage instead of global values
- Fixed `dashboard_stats` view to handle missing `is_active` field

### Test Fixture Updates
- Fixed field name mismatches:
  - `dispositionType` → `disposition_type` (3 occurrences)
  - `aliquotType` → `aliquot_type` (871 occurrences)
- Removed obsolete fields:
  - `description` from AliquotDisposition entries
  - `passage`, `experiment`, and `notes` from Aliquot entries
- Added required fields:
  - `created_at` and `updated_at` timestamps
  - `access_level` and `deleted` default fields

## Testing

- ✅ Test fixtures now load successfully (`make load-testdata`)
- ✅ Storage landing page should now display data correctly
- ✅ All 980 objects load from fixture file

## Related Issue

Fixes #79

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes storage dashboard errors and updates fixtures to match current schema.
> 
> - **Reports backend**:
>   - `dashboard_stats`: remove nonexistent `Device.is_active`; set `active_devices = storage_devices`.
>   - `storage_dashboard`: remove nonexistent `Device.is_active/device_type`; compute per-device capacity/usage; add `stored_aliquots`; iterate all devices.
> - **Test fixtures** (`tests/fixtures/sample_fixtures.json`):
>   - Field renames: `dispositionType` → `disposition_type`, `aliquotType` → `aliquot_type`.
>   - Remove obsolete fields from `Aliquot` and `AliquotDisposition` entries.
>   - Add required fields: `created_at`, `updated_at`, `access_level`, `deleted`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 328c167b3be842836022a17a2a62b625f36dd24e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->