### PR TITLE
Fix migration 0005: atomic=False to resolve PostgreSQL pending trigger error

### DIFF
--- a/krill/sample/migrations/0005_aliquot_redesign.py
+++ b/krill/sample/migrations/0005_aliquot_redesign.py
@@ -93,6 +93,8 @@ def migrate_aliquots_backward(apps, schema_editor):
 
 class Migration(migrations.Migration):
 
+    atomic = False
+
     dependencies = [
         ('sample', '0004_alter_aliquot_options_alter_sample_options'),
     ]


### PR DESCRIPTION
## Summary

- Sets `atomic = False` on migration `0005_aliquot_redesign` so each operation runs in its own autocommit context rather than one large transaction
- Fixes `ProgrammingError: there are pending deferred trigger events` that prevented the migration from running on production PostgreSQL

## Why

PostgreSQL deferred constraint triggers fire at transaction commit time. The existing migration wraps all operations (including `RunPython`) in a single transaction, which triggers the pending trigger error. Setting `atomic = False` lets each step commit independently, avoiding the conflict.

## Deploy notes

After merging and deploying, run the migration manually via the DigitalOcean console if it hasn't applied yet:
```bash
python krill/manage.py migrate
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)