### PR TITLE
Fix app.yaml: correct manage.py path so migrations run on deploy

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,7 +5,7 @@ services:
   github:
     repo: your-username/krill
     branch: main
-  run_command: python manage.py migrate && gunicorn krill.wsgi:application --bind 0.0.0.0:8000
+  run_command: python krill/manage.py migrate && gunicorn krill.wsgi:application --bind 0.0.0.0:8000
   environment_slug: python
   instance_count: 1
   instance_size_slug: basic-xxs


### PR DESCRIPTION
## Summary

- Fixes `run_command` in `app.yaml` to use `python krill/manage.py migrate` instead of `python manage.py migrate`
- `manage.py` lives at `krill/manage.py`, not the repo root — the old path was silently failing, meaning migrations never ran automatically on deploy

## Why this wasn't caught sooner

DigitalOcean App Platform appears to start gunicorn even when the migrate step fails, so there was no obvious deploy error — just missing migrations in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)