### PR TITLE
Fix N+1 queries on aliquot detail form (27s → fast)

### DIFF
--- a/krill/sample/forms.py
+++ b/krill/sample/forms.py
@@ -64,6 +64,7 @@ class AliquotForm(forms.ModelForm):
         from storage.models.storage import Box
         super().__init__(*args, **kwargs)
         self.fields['box'].queryset = Box.objects.all().order_by('name')
+        self.fields['parent'].queryset = Aliquot.objects.select_related('sample').all()
         self.fields['disposition'].required = True
 
     def clean(self):


### PR DESCRIPTION
## Summary

- `AliquotForm`'s `parent` field was using `Aliquot.objects.all()` with no `select_related`
- `Aliquot.__str__` accesses `self.sample.name`, so rendering the `<select>` dropdown fired one DB query per aliquot
- Adding `select_related('sample')` collapses this to a single JOIN query

Found via Sentry traces — the `/samples/detail/aliquot/<pk>/` page was taking ~27 seconds to load due to this N+1.

## Test plan

- [ ] Load `/samples/detail/aliquot/<pk>/` and confirm it loads in under a second
- [ ] Open the edit form and confirm the parent dropdown populates correctly
- [ ] Save an edit and confirm it works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)