### PR TITLE
Fix CSV import failing on BOM-prefixed and non-semicolon-delimited files

### DIFF
--- a/krill/person/tests/test_views.py
+++ b/krill/person/tests/test_views.py
@@ -742,3 +742,44 @@ MDA MB 134VI (MM134);UPMC/MJS;Sikora LN2 #1;4;F;1;2;Cells;3;Checked Out;Legacy M
             cleanup_mock.assert_called_once_with(fake_import_id, self.lab_admin_user.id)
         self.assertEqual(response.status_code, 200)
         self.assertIn('error', response.context)
+
+    def _csv_fixtures_from_bytes(self, raw_bytes):
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(suffix='.csv', delete=False) as f:
+            f.write(raw_bytes)
+            path = f.name
+        try:
+            return DataImportView().convert_csv_to_fixtures(path)
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_convert_csv_handles_utf8_bom(self):
+        """UTF-8 BOM prefix must not corrupt the first column name."""
+        raw = b'\xef\xbb\xbf' + self.test_csv_content.encode('utf-8')
+        fixtures = self._csv_fixtures_from_bytes(raw)
+        sources = [f for f in fixtures if f['model'] == 'sample.source']
+        self.assertGreater(len(sources), 0)
+
+    def test_convert_csv_handles_comma_delimiter(self):
+        """Comma-delimited CSV is parsed correctly via auto-detection."""
+        comma_content = self.test_csv_content.replace(';', ',')
+        fixtures = self._csv_fixtures_from_bytes(comma_content.encode('utf-8'))
+        sources = [f for f in fixtures if f['model'] == 'sample.source']
+        self.assertGreater(len(sources), 0)
+
+    def test_convert_csv_handles_tab_delimiter(self):
+        """Tab-delimited CSV is parsed correctly via auto-detection."""
+        tab_content = self.test_csv_content.replace(';', '\t')
+        fixtures = self._csv_fixtures_from_bytes(tab_content.encode('utf-8'))
+        sources = [f for f in fixtures if f['model'] == 'sample.source']
+        self.assertGreater(len(sources), 0)
+
+    def test_convert_csv_missing_required_columns_gives_helpful_error(self):
+        """Missing required columns raise an error that names both missing and found columns."""
+        bad_csv = b'Name;Value\nTest;123\n'
+        with self.assertRaises(Exception) as cm:
+            self._csv_fixtures_from_bytes(bad_csv)
+        msg = str(cm.exception)
+        self.assertIn('Source', msg)
+        self.assertIn('Name', msg)

--- a/krill/person/views.py
+++ b/krill/person/views.py
@@ -379,10 +379,37 @@ class DataImportView(TemplateView):
         aliquot_types = {}
         dispositions = {}
 
+        required_columns = {'Source', 'Cell Line', 'Freezer Name', 'Position 1', 'Position 2', 'Aliquot Type', 'Disposition'}
+
+        # Detect encoding: honour BOM if present, otherwise try UTF-8 then fall back to latin-1
+        with open(csv_file_path, 'rb') as f:
+            raw_start = f.read(4)
+        if raw_start.startswith((b'\xef\xbb\xbf',)):
+            encoding = 'utf-8-sig'
+        elif raw_start.startswith((b'\xff\xfe', b'\xfe\xff')):
+            encoding = 'utf-16'
+        else:
+            try:
+                with open(csv_file_path, 'r', encoding='utf-8') as f:
+                    f.read(4096)
+                encoding = 'utf-8'
+            except UnicodeDecodeError:
+                encoding = 'latin-1'
+
         # Read CSV file
-        with open(csv_file_path, 'r') as f:
-            reader = csv.DictReader(f, delimiter=';')
+        with open(csv_file_path, 'r', encoding=encoding) as f:
+            sample = f.read(4096)
+            f.seek(0)
+            try:
+                dialect = csv.Sniffer().sniff(sample, delimiters=',;\t|')
+                delimiter = dialect.delimiter
+            except csv.Error:
+                delimiter = ';'
+            reader = csv.DictReader(f, delimiter=delimiter)
             for row in reader:
+                missing = required_columns - row.keys()
+                if missing:
+                    raise KeyError(f"Missing required columns: {sorted(missing)}. Found: {sorted(row.keys())}")
                 # Create Source if not exists
                 source_name = row['Source'] or 'Unknown'
                 if source_name not in sources:


### PR DESCRIPTION
## Summary

- Fixes `KeyError: 'Source'` caused by UTF-8 BOM (`\xef\xbb\xbf`) emitted by Excel corrupting the first column name
- Auto-detects CSV delimiter via `csv.Sniffer` so comma- and tab-delimited files work without reconfiguration
- Adds encoding fallback chain (utf-8-sig → utf-8 → latin-1) to handle files regardless of encoding
- Adds a missing-columns error that lists what was found vs. expected for easier debugging

## Test plan

- [ ] `test_convert_csv_handles_utf8_bom` — BOM-prefixed file parses correctly
- [ ] `test_convert_csv_handles_comma_delimiter` — comma-delimited file auto-detected
- [ ] `test_convert_csv_handles_tab_delimiter` — tab-delimited file auto-detected
- [ ] `test_convert_csv_missing_required_columns_gives_helpful_error` — bad file gives actionable error message
- [ ] Full `DataImportViewTest` suite (12 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)