### PR TITLE
feat: clickable aliquot table rows (#133)

### DIFF
--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -148,6 +148,19 @@ class SampleListViewTest(SampleViewTest):
         self.assertContains(response, 'status-badge in-use')
         self.assertNotContains(response, 'status-badge in_use')
 
+    def test_aliquot_table_rows_have_data_url_for_navigation(self):
+        """Each aliquot table row has a data-url attribute pointing to its detail view."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        expected_url = reverse('sample:detail', kwargs={'type': 'aliquot', 'pk': self.aliquot.id})
+        self.assertContains(response, f'data-url="{expected_url}"')
+
+    def test_aliquot_action_button_has_target_blank(self):
+        """Aliquot detail action button opens in a new tab."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        self.assertContains(response, 'target="_blank"')
+
 
 class ModelCreateViewTest(SampleViewTest):
     """Test cases for the ModelCreateView"""

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -98,7 +98,7 @@
                     </thead>
                     <tbody>
                         {% for item in items %}
-                        <tr>
+                        <tr data-url="{% url 'sample:detail' type='aliquot' pk=item.id %}">
                             <td><a href="{% url 'sample:detail' type='aliquot' pk=item.id %}">{{ item.sample.name }} <span style="color:var(--color-dark-variant);font-weight:400">#{{ item.id }}</span></a></td>
                             <td>{% if item.aliquot_type %}<span class="status-badge">{{ item.aliquot_type.name }}</span>{% else %}—{% endif %}</td>
                             <td>{% if item.disposition %}<span class="status-badge {{ item.disposition.css_class }}">{{ item.disposition.name }}</span>{% else %}—{% endif %}</td>
@@ -113,7 +113,7 @@
                             <td>{{ item.created_at|date:"Y-m-d" }}</td>
                             <td>{{ item.get_access_level_display }}</td>
                             <td>
-                                <a class="action-button view" href="{% url 'sample:detail' type='aliquot' pk=item.id %}" title="View">
+                                <a class="action-button view" href="{% url 'sample:detail' type='aliquot' pk=item.id %}" target="_blank" title="Open in new tab">
                                     <span class="material-icons-round">open_in_new</span>
                                 </a>
                             </td>
@@ -345,6 +345,14 @@ function viewItem(itemId) {
 function viewSample(sampleId) {
     window.location.href = `{% url 'sample:sample_list' %}../detail/sample/${sampleId}/`;
 }
+
+document.querySelectorAll('tr[data-url]').forEach(function(row) {
+    row.addEventListener('click', function(e) {
+        if (!e.target.closest('a, button')) {
+            window.location.href = row.dataset.url;
+        }
+    });
+});
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- Each aliquot \`<tr>\` gets a \`data-url\` attribute; a JS click handler navigates the page on row click
- Clicks on child \`<a>\` or \`<button>\` elements are ignored so the action icon still works independently
- Action button (\`open_in_new\`) now has \`target="_blank"\` — explicitly opens detail in a new tab

## Test plan
- [ ] \`uv run python manage.py test sample.tests.test_views.SampleListViewTest\` passes
- [ ] Clicking anywhere on a row in \`/sample/?type=aliquot\` navigates to the detail view
- [ ] Clicking the \`open_in_new\` icon opens the detail in a new tab

Closes #133