### PR TITLE
fix: disposition badge contrast and CSS class mismatch (#132)

### DIFF
--- a/krill/sample/models/aliquot.py
+++ b/krill/sample/models/aliquot.py
@@ -21,6 +21,11 @@ class AliquotDisposition(models.Model):
     name = models.CharField(max_length=100, unique=True)
     disposition_type = models.CharField(max_length=20, choices=DISPOSITION_CHOICES, default='stored')
 
+    @property
+    def css_class(self):
+        """Return the disposition_type with underscores replaced by hyphens for CSS class use."""
+        return self.disposition_type.replace('_', '-')
+
     def __str__(self):
         return self.name
 

--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -130,6 +130,24 @@ class SampleListViewTest(SampleViewTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.context['items']), 50)
 
+    def test_stored_disposition_badge_renders_correct_css_class(self):
+        """stored disposition renders with 'stored' CSS class."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        self.assertContains(response, 'status-badge stored')
+
+    def test_in_use_disposition_badge_renders_hyphenated_css_class(self):
+        """in_use disposition renders with 'in-use' CSS class, not 'in_use'."""
+        in_use = AliquotDisposition.objects.create(
+            name='In Use Test', disposition_type='in_use'
+        )
+        self.aliquot.disposition = in_use
+        self.aliquot.save()
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        self.assertContains(response, 'status-badge in-use')
+        self.assertNotContains(response, 'status-badge in_use')
+
 
 class ModelCreateViewTest(SampleViewTest):
     """Test cases for the ModelCreateView"""

--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -2080,18 +2080,23 @@ main table tbody tr:last-child td{
 }
 
 .status-badge.stored {
-    background: var(--color-success-light);
-    color: var(--color-success-dark);
+    background: #0d7a6a;
+    color: #fff;
 }
 
 .status-badge.in-use {
-    background: var(--color-warning-light);
-    color: var(--color-warning-dark);
+    background: #1f5fa6;
+    color: #fff;
 }
 
 .status-badge.exhausted {
-    background: var(--color-danger-light);
-    color: var(--color-danger-dark);
+    background: #b83300;
+    color: #fff;
+}
+
+.status-badge.disposed {
+    background: #4a5568;
+    color: #fff;
 }
 
 /* Storage Statistics */

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -101,7 +101,7 @@
                         <tr>
                             <td><a href="{% url 'sample:detail' type='aliquot' pk=item.id %}">{{ item.sample.name }} <span style="color:var(--color-dark-variant);font-weight:400">#{{ item.id }}</span></a></td>
                             <td>{% if item.aliquot_type %}<span class="status-badge">{{ item.aliquot_type.name }}</span>{% else %}—{% endif %}</td>
-                            <td>{% if item.disposition %}<span class="status-badge {{ item.disposition.disposition_type }}">{{ item.disposition.name }}</span>{% else %}—{% endif %}</td>
+                            <td>{% if item.disposition %}<span class="status-badge {{ item.disposition.css_class }}">{{ item.disposition.name }}</span>{% else %}—{% endif %}</td>
                             <td>
                                 {% if item.location %}
                                     {{ item.location.box.rack.shelf.device.site.name }} ›


### PR DESCRIPTION
## Summary
- Adds a `css_class` property to `AliquotDisposition` that converts `in_use` → `in-use` (Django's `slugify` preserves underscores, so the template used `item.disposition.css_class` instead)
- Updates the aliquot list template to use `item.disposition.css_class` so `in_use` correctly maps to the `in-use` CSS rule
- Adds `.status-badge.disposed` rule (was missing entirely)
- Switches all four disposition badges to solid-fill with white text for legible contrast in both light and dark mode

## Test plan
- [ ] `uv run python manage.py test sample.tests.test_views.SampleListViewTest` passes (133 total, 0 failures)
- [ ] On `/sample/?type=aliquot`, all disposition badges are visibly distinct and readable in both themes

Closes #132