### PR TITLE
fix: darken accent color for light mode WCAG AA contrast (#120)

### DIFF
--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap');
 
 :root{
-    --color-primary: #6C9BCF;
+    --color-primary: #1f5fa6;
     --color-danger: #FF0060;
     --color-success: #1B9C85;
     --color-warning: #F7D060;
@@ -40,7 +40,7 @@
     /* Softer button colors for better UX */
     --color-success-soft: #4CAF50;
     --color-danger-soft: #E91E63;
-    --color-primary-soft: #5C9CE6;
+    --color-primary-soft: #1f5fa6;
     --color-info-soft: #7E57C2;
 
     --card-border-radius: 2rem;
@@ -61,6 +61,8 @@
     --color-dark-variant: #a3bdcc;
     --color-light: rgba(0, 0, 0, 0.4);
     --box-shadow: 0 2rem 3rem var(--color-light);
+    --color-primary: #6C9BCF;
+    --color-primary-soft: #5C9CE6;
 
     /* Dark mode status badge colors - adjusted for dark theme */
     --color-danger-light: #2d1b1e;


### PR DESCRIPTION
## Summary
- \`--color-primary: #6C9BCF\` had ~2.7:1 contrast on white — well below WCAG AA (4.5:1)
- Overrides \`--color-primary\` and \`--color-primary-soft\` to \`#1f5fa6\` (~7.5:1) in \`:root\` (light mode)
- Restores original values in \`.dark-mode-variables\` so dark mode appearance is unchanged

## Test plan
- [ ] \`uv run python manage.py test\` passes (no regressions)
- [ ] In light mode: buttons, sidebar active state, and table sort indicators are visibly darker and legible
- [ ] In dark mode: no visible change

Closes #120