### PR TITLE
feat: pull brand orange into active sidebar indicator (#126)

### DIFF
--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -37,6 +37,9 @@
     --color-danger-darker: #cc0000;
     --color-warning-darker: #cc8800;
 
+    /* Brand accent — matches the krill logo */
+    --color-brand-orange: #F4A07A;
+
     /* Softer button colors for better UX */
     --color-success-soft: #4CAF50;
     --color-danger-soft: #E91E63;
@@ -338,12 +341,12 @@ aside .sidebar a.active::before{
     transform: translateY(-50%);
     width: 4px;
     height: 18px;
-    background-color: var(--color-primary);
+    background-color: var(--color-brand-orange);
     border-radius: 0 2px 2px 0;
 }
 
 aside .sidebar a.active span:first-of-type{
-    color: var(--color-primary);
+    color: var(--color-brand-orange);
 }
 
 aside .sidebar a:hover{


### PR DESCRIPTION
## Summary
- Adds `--color-brand-orange: #F4A07A` CSS token (sampled from the krill shrimp logo)
- Applies it to the active sidebar left-bar indicator and nav icon
- Text color stays dark blue for readability — orange is used only as the accent

## Test plan
- [ ] Active sidebar item shows orange left bar and icon on every page
- [ ] Inactive items and hover states are unaffected
- [ ] Both light and dark mode look correct

Closes #126