### PR TITLE
feat: inline filter toolbar, filter chips, sortable headers (#118)

### DIFF
--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -193,6 +193,12 @@ class SampleListViewTest(SampleViewTest):
         self.assertEqual(response.context['disposition_filter'], 'stored')
         self.assertEqual(response.context['aliquot_type_filter'], '')
 
+    def test_aliquot_sort_header_has_active_class(self):
+        """The sorted column's <th> has sort-asc or sort-desc class in the response."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&sort=sample&order=asc')
+        self.assertContains(response, 'sort-asc')
+
 
 class ModelCreateViewTest(SampleViewTest):
     """Test cases for the ModelCreateView"""

--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -161,6 +161,38 @@ class SampleListViewTest(SampleViewTest):
         response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
         self.assertContains(response, 'target="_blank"')
 
+    def test_aliquot_list_filters_by_disposition(self):
+        """?disposition=stored returns only aliquots with that disposition type."""
+        from sample.models.aliquot import AliquotDisposition
+        in_use = AliquotDisposition.objects.create(name='In Use', disposition_type='in_use')
+        other_aliquot = Aliquot.objects.create(sample=self.sample, disposition=in_use)
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&disposition=stored')
+        self.assertEqual(response.status_code, 200)
+        items = response.context['items']
+        self.assertIn(self.aliquot, items)
+        self.assertNotIn(other_aliquot, items)
+
+    def test_aliquot_list_filters_by_aliquot_type(self):
+        """?aliquot_type=<id> returns only aliquots with that type."""
+        other_type = AliquotType.objects.create(name='Other Type')
+        other_aliquot = Aliquot.objects.create(sample=self.sample, aliquot_type=other_type, disposition=self.stored_disposition)
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + f'?type=aliquot&aliquot_type={self.aliquot_type.id}')
+        self.assertEqual(response.status_code, 200)
+        items = response.context['items']
+        self.assertIn(self.aliquot, items)
+        self.assertNotIn(other_aliquot, items)
+
+    def test_aliquot_list_context_includes_filter_choices(self):
+        """Context includes disposition_choices, aliquot_types, and active filter values."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&disposition=stored')
+        self.assertIn('disposition_choices', response.context)
+        self.assertIn('aliquot_types', response.context)
+        self.assertEqual(response.context['disposition_filter'], 'stored')
+        self.assertEqual(response.context['aliquot_type_filter'], '')
+
 
 class ModelCreateViewTest(SampleViewTest):
     """Test cases for the ModelCreateView"""

--- a/krill/sample/views/list.py
+++ b/krill/sample/views/list.py
@@ -2,7 +2,7 @@ from django.views.generic import ListView
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from ..models.sample import Sample
-from ..models.aliquot import Aliquot, AliquotType, AliquotLocation
+from ..models.aliquot import Aliquot, AliquotType, AliquotDisposition, AliquotLocation
 from ..models.source import Source
 
 class SampleListView(LoginRequiredMixin, ListView):
@@ -12,7 +12,6 @@ class SampleListView(LoginRequiredMixin, ListView):
     def get_queryset(self):
         model_type = self.request.GET.get('type', 'sample')
 
-        # Get the queryset based on model type
         if model_type == 'aliquot':
             queryset = Aliquot.objects.select_related(
                 'sample',
@@ -24,10 +23,10 @@ class SampleListView(LoginRequiredMixin, ListView):
             queryset = AliquotType.objects.all()
         elif model_type == 'source':
             queryset = Source.objects.all()
-        else:  # default to samples
+        else:
             queryset = Sample.objects.select_related('source')
 
-        # Apply search filtering if provided
+        # Text search
         search_query = self.request.GET.get('q', '')
         if search_query:
             if model_type == 'aliquot':
@@ -35,49 +34,43 @@ class SampleListView(LoginRequiredMixin, ListView):
                     Q(sample__name__icontains=search_query) |
                     Q(aliquot_type__name__icontains=search_query)
                 )
-            elif model_type == 'sample':
-                queryset = queryset.filter(name__icontains=search_query)
-            elif model_type == 'source':
-                queryset = queryset.filter(name__icontains=search_query)
-            elif model_type == 'aliquot-type':
+            elif model_type in ('sample', 'source', 'aliquot-type'):
                 queryset = queryset.filter(name__icontains=search_query)
 
-        # Apply sorting
+        # Aliquot-specific filters
+        if model_type == 'aliquot':
+            disposition_filter = self.request.GET.get('disposition', '')
+            if disposition_filter:
+                queryset = queryset.filter(disposition__disposition_type=disposition_filter)
+
+            aliquot_type_filter = self.request.GET.get('aliquot_type', '')
+            if aliquot_type_filter:
+                queryset = queryset.filter(aliquot_type__id=aliquot_type_filter)
+
+        # Sorting
         sort_by = self.request.GET.get('sort', 'name')
         sort_order = self.request.GET.get('order', 'asc')
 
         if sort_order == 'desc':
-            sort_by = f'-{sort_by}'
-
-        # Handle special cases for computed properties and non-database fields
-        if model_type == 'aliquot' and sort_by.replace('-', '') == 'disposition':
-            # Disposition is a computed property, so we can't sort by it directly
-            # Instead, sort by sample name and id for consistent pagination
-            queryset = queryset.order_by('sample__name', 'id')
-        elif model_type == 'aliquot' and sort_by.replace('-', '') == 'type':
-            # Map 'type' to 'aliquot_type__name' for proper sorting
-            sort_field = 'aliquot_type__name' if not sort_by.startswith('-') else '-aliquot_type__name'
-            queryset = queryset.order_by(sort_field, 'id')
-        elif model_type == 'aliquot' and sort_by.replace('-', '') == 'sample':
-            # Map 'sample' to 'sample__name' for proper sorting
-            sort_field = 'sample__name' if not sort_by.startswith('-') else '-sample__name'
-            queryset = queryset.order_by(sort_field, 'id')
-        elif hasattr(queryset.model, sort_by.replace('-', '')):
-            # Check if it's actually a database field, not just a property
-            field_name = sort_by.replace('-', '')
-            field = queryset.model._meta.get_field(field_name)
-            if field:
-                queryset = queryset.order_by(sort_by)
-            else:
-                # It's a property, not a field, so use default sorting
-                if model_type == 'aliquot':
-                    queryset = queryset.order_by('sample__name', 'id')
-                elif hasattr(queryset.model, 'name'):
-                    queryset = queryset.order_by('name', 'id')
-                else:
-                    queryset = queryset.order_by('id')
+            sort_prefix = '-'
         else:
-            # Default sorting - use appropriate field for consistent pagination
+            sort_prefix = ''
+
+        if model_type == 'aliquot' and sort_by == 'disposition':
+            queryset = queryset.order_by('sample__name', 'id')
+        elif model_type == 'aliquot' and sort_by == 'type':
+            queryset = queryset.order_by(f'{sort_prefix}aliquot_type__name', 'id')
+        elif model_type == 'aliquot' and sort_by == 'sample':
+            queryset = queryset.order_by(f'{sort_prefix}sample__name', 'id')
+        elif model_type == 'aliquot' and sort_by == 'created_at':
+            queryset = queryset.order_by(f'{sort_prefix}created_at', 'id')
+        elif hasattr(queryset.model, sort_by):
+            try:
+                queryset.model._meta.get_field(sort_by)
+                queryset = queryset.order_by(f'{sort_prefix}{sort_by}')
+            except Exception:
+                queryset = queryset.order_by('sample__name', 'id') if model_type == 'aliquot' else queryset.order_by('name', 'id')
+        else:
             if model_type == 'aliquot':
                 queryset = queryset.order_by('sample__name', 'id')
             elif hasattr(queryset.model, 'name'):
@@ -97,19 +90,23 @@ class SampleListView(LoginRequiredMixin, ListView):
         model_type = self.request.GET.get('type', 'sample')
         context['model_type'] = model_type
 
-        # Set model name
         if model_type == 'aliquot':
             context['model_name'] = 'Aliquots'
         elif model_type == 'aliquot-type':
             context['model_name'] = 'Aliquot Types'
         elif model_type == 'source':
             context['model_name'] = 'Sources'
-        else:  # default to samples
+        else:
             context['model_name'] = 'Samples'
 
-        # Add search and sort context
         context['search_query'] = self.request.GET.get('q', '')
         context['sort_by'] = self.request.GET.get('sort', 'name')
         context['sort_order'] = self.request.GET.get('order', 'asc')
+
+        # Aliquot filter context
+        context['disposition_filter'] = self.request.GET.get('disposition', '')
+        context['aliquot_type_filter'] = self.request.GET.get('aliquot_type', '')
+        context['disposition_choices'] = AliquotDisposition.DISPOSITION_CHOICES
+        context['aliquot_types'] = AliquotType.objects.order_by('name')
 
         return context

--- a/krill/sample/views/list.py
+++ b/krill/sample/views/list.py
@@ -40,12 +40,16 @@ class SampleListView(LoginRequiredMixin, ListView):
         # Aliquot-specific filters
         if model_type == 'aliquot':
             disposition_filter = self.request.GET.get('disposition', '')
-            if disposition_filter:
+            valid_dispositions = [c[0] for c in AliquotDisposition.DISPOSITION_CHOICES]
+            if disposition_filter and disposition_filter in valid_dispositions:
                 queryset = queryset.filter(disposition__disposition_type=disposition_filter)
 
             aliquot_type_filter = self.request.GET.get('aliquot_type', '')
             if aliquot_type_filter:
-                queryset = queryset.filter(aliquot_type__id=aliquot_type_filter)
+                try:
+                    queryset = queryset.filter(aliquot_type__id=int(aliquot_type_filter))
+                except (ValueError, TypeError):
+                    pass
 
         # Sorting
         sort_by = self.request.GET.get('sort', 'name')
@@ -57,7 +61,7 @@ class SampleListView(LoginRequiredMixin, ListView):
             sort_prefix = ''
 
         if model_type == 'aliquot' and sort_by == 'disposition':
-            queryset = queryset.order_by('sample__name', 'id')
+            queryset = queryset.order_by(f'{sort_prefix}disposition__disposition_type', 'id')
         elif model_type == 'aliquot' and sort_by == 'type':
             queryset = queryset.order_by(f'{sort_prefix}aliquot_type__name', 'id')
         elif model_type == 'aliquot' and sort_by == 'sample':
@@ -104,9 +108,15 @@ class SampleListView(LoginRequiredMixin, ListView):
         context['sort_order'] = self.request.GET.get('order', 'asc')
 
         # Aliquot filter context
-        context['disposition_filter'] = self.request.GET.get('disposition', '')
-        context['aliquot_type_filter'] = self.request.GET.get('aliquot_type', '')
-        context['disposition_choices'] = AliquotDisposition.DISPOSITION_CHOICES
-        context['aliquot_types'] = AliquotType.objects.order_by('name')
+        if model_type == 'aliquot':
+            context['disposition_filter'] = self.request.GET.get('disposition', '')
+            context['aliquot_type_filter'] = self.request.GET.get('aliquot_type', '')
+            context['disposition_choices'] = AliquotDisposition.DISPOSITION_CHOICES
+            context['aliquot_types'] = AliquotType.objects.order_by('name')
+        else:
+            context['disposition_filter'] = ''
+            context['aliquot_type_filter'] = ''
+            context['disposition_choices'] = []
+            context['aliquot_types'] = AliquotType.objects.none()
 
         return context

--- a/krill/sample/views/list.py
+++ b/krill/sample/views/list.py
@@ -107,6 +107,11 @@ class SampleListView(LoginRequiredMixin, ListView):
         context['sort_by'] = self.request.GET.get('sort', 'name')
         context['sort_order'] = self.request.GET.get('order', 'asc')
 
+        # Build a query string with all current params except 'page' for pagination links
+        params = self.request.GET.copy()
+        params.pop('page', None)
+        context['query_string'] = params.urlencode()
+
         # Aliquot filter context
         if model_type == 'aliquot':
             context['disposition_filter'] = self.request.GET.get('disposition', '')

--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -2543,3 +2543,99 @@ main table tbody tr:last-child td{
         align-items: stretch;
     }
 }
+
+/* ── Inline filter toolbar (aliquot list) ─────────────────────────── */
+.filter-toolbar {
+    margin-bottom: 1rem;
+}
+
+.toolbar-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.toolbar-search {
+    flex: 1;
+    min-width: 160px;
+    padding: 0.45rem 0.75rem;
+    border: 1px solid var(--color-gray-border);
+    border-radius: var(--border-radius-1);
+    background: var(--color-white);
+    color: var(--color-dark);
+    font-size: 0.88rem;
+    font-family: var(--font-family);
+}
+
+.toolbar-search:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+.toolbar-filter {
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--color-gray-border);
+    border-radius: var(--border-radius-1);
+    background: var(--color-white);
+    color: var(--color-dark);
+    font-size: 0.85rem;
+    font-family: var(--font-family);
+    cursor: pointer;
+}
+
+.toolbar-filter:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+.toolbar-btn-search {
+    display: flex;
+    align-items: center;
+    padding: 0.45rem 0.6rem;
+    border: none;
+    border-radius: var(--border-radius-1);
+    background: var(--color-primary);
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+.toolbar-btn-search:hover {
+    opacity: 0.88;
+}
+
+/* Filter chips */
+.filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 0.5rem;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: var(--color-primary);
+    color: #fff;
+    font-size: 0.78rem;
+    font-weight: 500;
+}
+
+.chip-remove {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+    opacity: 0.8;
+}
+
+.chip-remove:hover {
+    opacity: 1;
+}

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -8,7 +8,59 @@
         <p>Browse and manage {{ model_name|lower }}</p>
     </div>
 
-    <!-- Search and Filter Form -->
+    <!-- Filter toolbar (aliquot) / search card (other types) -->
+    {% if model_type == 'aliquot' %}
+    <div class="filter-toolbar">
+        <form id="sampleListForm" action="{% url 'sample:sample_list' %}" method="get">
+            <input type="hidden" name="type" value="aliquot">
+            <div class="toolbar-row">
+                <input type="text" name="q" class="toolbar-search"
+                       placeholder="Search aliquots..." value="{{ search_query }}">
+                <select name="disposition" class="toolbar-filter" onchange="this.form.submit()">
+                    <option value="">+ Disposition</option>
+                    {% for value, label in disposition_choices %}
+                    <option value="{{ value }}" {% if disposition_filter == value %}selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                </select>
+                <select name="aliquot_type" class="toolbar-filter" onchange="this.form.submit()">
+                    <option value="">+ Type</option>
+                    {% for at in aliquot_types %}
+                    <option value="{{ at.id }}" {% if aliquot_type_filter == at.id|stringformat:"i" %}selected{% endif %}>{{ at.name }}</option>
+                    {% endfor %}
+                </select>
+                <button type="submit" class="toolbar-btn-search" title="Search">
+                    <span class="material-icons-round">search</span>
+                </button>
+                <a class="btn btn-success" href="{% url 'sample:sample_create' %}?type=aliquot">
+                    <span class="material-icons-round">add</span>
+                    New Aliquot
+                </a>
+            </div>
+        </form>
+        {% if search_query or disposition_filter or aliquot_type_filter %}
+        <div class="filter-chips">
+            {% if search_query %}
+            <span class="filter-chip">
+                "{{ search_query }}"
+                <button type="button" class="chip-remove" onclick="removeFilterParam('q')" title="Remove">×</button>
+            </span>
+            {% endif %}
+            {% if disposition_filter %}
+            <span class="filter-chip">
+                Disposition: {{ disposition_filter|title }}
+                <button type="button" class="chip-remove" onclick="removeFilterParam('disposition')" title="Remove">×</button>
+            </span>
+            {% endif %}
+            {% if aliquot_type_filter %}
+            <span class="filter-chip">
+                Type: {% for at in aliquot_types %}{% if at.id|stringformat:"i" == aliquot_type_filter %}{{ at.name }}{% endif %}{% endfor %}
+                <button type="button" class="chip-remove" onclick="removeFilterParam('aliquot_type')" title="Remove">×</button>
+            </span>
+            {% endif %}
+        </div>
+        {% endif %}
+    </div>
+    {% else %}
     <div class="search-form-container">
         <form id="sampleListForm" class="search-form" action="{% url 'sample:sample_list' %}" method="get">
             {% if request.GET.type %}
@@ -58,6 +110,7 @@
             </div>
         </form>
     </div>
+    {% endif %}
 
     <!-- Results -->
     <div class="search-results">
@@ -353,6 +406,12 @@ document.querySelectorAll('tr[data-url]').forEach(function(row) {
         }
     });
 });
+
+function removeFilterParam(param) {
+    var url = new URL(window.location.href);
+    url.searchParams.delete(param);
+    window.location.href = url.toString();
+}
 </script>
 
 <style>

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -13,16 +13,20 @@
     <div class="filter-toolbar">
         <form id="sampleListForm" action="{% url 'sample:sample_list' %}" method="get">
             <input type="hidden" name="type" value="aliquot">
+            {% if request.GET.sort %}<input type="hidden" name="sort" value="{{ request.GET.sort }}">{% endif %}
+            {% if request.GET.order %}<input type="hidden" name="order" value="{{ request.GET.order }}">{% endif %}
+            {% if request.GET.page_size %}<input type="hidden" name="page_size" value="{{ request.GET.page_size }}">{% endif %}
             <div class="toolbar-row">
                 <input type="text" name="q" class="toolbar-search"
-                       placeholder="Search aliquots..." value="{{ search_query }}">
-                <select name="disposition" class="toolbar-filter" onchange="this.form.submit()">
+                       placeholder="Search aliquots..." value="{{ search_query }}"
+                       aria-label="Search aliquots">
+                <select name="disposition" class="toolbar-filter" onchange="this.form.submit()" aria-label="Filter by disposition">
                     <option value="">+ Disposition</option>
                     {% for value, label in disposition_choices %}
                     <option value="{{ value }}" {% if disposition_filter == value %}selected{% endif %}>{{ label }}</option>
                     {% endfor %}
                 </select>
-                <select name="aliquot_type" class="toolbar-filter" onchange="this.form.submit()">
+                <select name="aliquot_type" class="toolbar-filter" onchange="this.form.submit()" aria-label="Filter by type">
                     <option value="">+ Type</option>
                     {% for at in aliquot_types %}
                     <option value="{{ at.id }}" {% if aliquot_type_filter == at.id|stringformat:"i" %}selected{% endif %}>{{ at.name }}</option>
@@ -328,7 +332,7 @@
             {% if is_paginated %}
             <div class="pagination">
                 {% if page_obj.has_previous %}
-                    <a href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.sort %}sort={{ request.GET.sort }}&{% endif %}{% if request.GET.order %}order={{ request.GET.order }}&{% endif %}{% if request.GET.type %}type={{ request.GET.type }}&{% endif %}page={{ page_obj.previous_page_number }}" class="page-link">
+                    <a href="?{{ query_string }}{% if query_string %}&{% endif %}page={{ page_obj.previous_page_number }}" class="page-link">
                         <span class="material-icons-round">chevron_left</span>
                         Previous
                     </a>
@@ -339,7 +343,7 @@
                 </span>
 
                 {% if page_obj.has_next %}
-                    <a href="?{% if request.GET.q %}q={{ request.GET.q }}&{% endif %}{% if request.GET.sort %}sort={{ request.GET.sort }}&{% endif %}{% if request.GET.order %}order={{ request.GET.order }}&{% endif %}{% if request.GET.type %}type={{ request.GET.type }}&{% endif %}page={{ page_obj.next_page_number }}" class="page-link">
+                    <a href="?{{ query_string }}{% if query_string %}&{% endif %}page={{ page_obj.next_page_number }}" class="page-link">
                         Next
                         <span class="material-icons-round">chevron_right</span>
                     </a>

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -144,11 +144,11 @@
                 <table class="items-table">
                     <thead>
                         <tr>
-                            <th>Aliquot</th>
-                            <th>Type</th>
-                            <th>Disposition</th>
+                            <th data-sort="sample" class="{% if sort_by == 'sample' %}sort-{{ sort_order }}{% endif %}">Aliquot</th>
+                            <th data-sort="type" class="{% if sort_by == 'type' %}sort-{{ sort_order }}{% endif %}">Type</th>
+                            <th data-sort="disposition" class="{% if sort_by == 'disposition' %}sort-{{ sort_order }}{% endif %}">Disposition</th>
                             <th>Location</th>
-                            <th>Created</th>
+                            <th data-sort="created_at" class="{% if sort_by == 'created_at' %}sort-{{ sort_order }}{% endif %}">Created</th>
                             <th>Access</th>
                             <th></th>
                         </tr>
@@ -416,6 +416,20 @@ function removeFilterParam(param) {
     url.searchParams.delete(param);
     window.location.href = url.toString();
 }
+
+document.querySelectorAll('th[data-sort]').forEach(function(th) {
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', function() {
+        var col = this.dataset.sort;
+        var params = new URLSearchParams(window.location.search);
+        var currentSort = params.get('sort');
+        var currentOrder = params.get('order') || 'asc';
+        params.set('sort', col);
+        params.set('order', (currentSort === col && currentOrder === 'asc') ? 'desc' : 'asc');
+        params.delete('page');
+        window.location.href = window.location.pathname + '?' + params.toString();
+    });
+});
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
- Replaces the aliquot list search card with a one-row filter toolbar (search + disposition dropdown + type dropdown)
- Selecting a filter auto-submits; active filters appear as removable chips with × to clear individually
- Column headers on the aliquot table are clickable to sort; sorted column shows ↑/↓ caret
- Filter/sort state is preserved across pagination and toolbar form submissions
- Backend: `?disposition=` and `?aliquot_type=` query params added to `SampleListView`
- Non-aliquot list types (Samples, Sources, Aliquot Types) are unaffected

## Test plan
- [ ] `uv run python manage.py test sample` passes
- [ ] `/sample/?type=aliquot` — toolbar renders, disposition/type dropdowns filter correctly
- [ ] Selecting a filter shows a chip; clicking × removes that filter
- [ ] Clicking a column header sorts; clicking again reverses; caret shows on sorted column
- [ ] Sorting then filtering a dropdown preserves sort state
- [ ] Navigating to page 2 preserves active filters

Closes #118