### PR TITLE
fix: truncate location column to prevent overflow (#115)

### DIFF
--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -199,6 +199,26 @@ class SampleListViewTest(SampleViewTest):
         response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&sort=sample&order=asc')
         self.assertContains(response, 'sort-asc')
 
+    def test_aliquot_location_cell_has_title_with_full_path(self):
+        """Location cell renders a title attribute with the full storage path."""
+        location = AliquotLocation.objects.create(
+            aliquot=self.aliquot, box=self.box, row=1, column=2
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        self.assertContains(response, 'title="Test Site')
+        self.assertContains(response, 'Test Device')
+        self.assertContains(response, 'Test Box')
+
+    def test_aliquot_location_cell_has_truncation_class(self):
+        """Location cell has the CSS truncation class."""
+        AliquotLocation.objects.create(
+            aliquot=self.aliquot, box=self.box, row=1, column=2
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        self.assertContains(response, 'location-breadcrumb')
+
 
 class ModelCreateViewTest(SampleViewTest):
     """Test cases for the ModelCreateView"""

--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -2639,3 +2639,13 @@ main table tbody tr:last-child td{
 .chip-remove:hover {
     opacity: 1;
 }
+
+/* ── Location breadcrumb truncation ──────────────────────────────── */
+.location-breadcrumb {
+    display: block;
+    max-width: 180px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: default;
+}

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -161,10 +161,12 @@
                             <td>{% if item.disposition %}<span class="status-badge {{ item.disposition.css_class }}">{{ item.disposition.name }}</span>{% else %}—{% endif %}</td>
                             <td>
                                 {% if item.location %}
-                                    {{ item.location.box.rack.shelf.device.site.name }} ›
+                                <span class="location-breadcrumb"
+                                      title="{{ item.location.box.rack.shelf.device.site.name }} › {{ item.location.box.rack.shelf.device.name }} › {{ item.location.box.name }} ({{ item.location.row }}, {{ item.location.column }})">
                                     {{ item.location.box.rack.shelf.device.name }} ›
-                                    {{ item.location.box.name }}
-                                    [{{ item.location.row }}, {{ item.location.column }}]
+                                    {{ item.location.box.name }} ›
+                                    ({{ item.location.row }}, {{ item.location.column }})
+                                </span>
                                 {% else %}—{% endif %}
                             </td>
                             <td>{{ item.created_at|date:"Y-m-d" }}</td>


### PR DESCRIPTION
## Summary
- Location cell now displays only `Device › Box › (row, col)` — just enough context without overflowing
- Full path (`Site › Device › Box (row, col)`) surfaces on hover via `title` attribute
- `.location-breadcrumb` CSS class enforces `max-width: 180px` + `text-overflow: ellipsis`

## Test plan
- [ ] `uv run python manage.py test sample` passes
- [ ] On `/samples/list/?type=aliquot`, location cells no longer run into the Created column
- [ ] Hovering a location cell shows the full path as a tooltip

Closes #115