### PR TITLE
fix: clickable sort headers on all list tables (#144)

### DIFF
--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -199,6 +199,18 @@ class SampleListViewTest(SampleViewTest):
         response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&sort=sample&order=asc')
         self.assertContains(response, 'sort-asc')
 
+    def test_aliquot_location_sort_header_has_active_class(self):
+        """Location <th> gets sort-asc class when sorted by location."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot&sort=location&order=asc')
+        self.assertContains(response, 'sort-asc')
+
+    def test_sample_list_sort_header_has_active_class(self):
+        """Name <th> gets sort-asc class on the sample list."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?sort=name&order=asc')
+        self.assertContains(response, 'sort-asc')
+
     def test_aliquot_location_cell_has_title_with_full_path(self):
         """Location cell renders a title attribute with the full storage path."""
         location = AliquotLocation.objects.create(

--- a/krill/sample/views/list.py
+++ b/krill/sample/views/list.py
@@ -68,6 +68,10 @@ class SampleListView(LoginRequiredMixin, ListView):
             queryset = queryset.order_by(f'{sort_prefix}sample__name', 'id')
         elif model_type == 'aliquot' and sort_by == 'created_at':
             queryset = queryset.order_by(f'{sort_prefix}created_at', 'id')
+        elif model_type == 'aliquot' and sort_by == 'location':
+            queryset = queryset.order_by(f'{sort_prefix}location__box__rack__shelf__device__name', 'id')
+        elif model_type == 'sample' and sort_by == 'source':
+            queryset = queryset.order_by(f'{sort_prefix}source__name', 'id')
         elif hasattr(queryset.model, sort_by):
             try:
                 queryset.model._meta.get_field(sort_by)

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -147,7 +147,7 @@
                             <th data-sort="sample" class="{% if sort_by == 'sample' %}sort-{{ sort_order }}{% endif %}">Aliquot</th>
                             <th data-sort="type" class="{% if sort_by == 'type' %}sort-{{ sort_order }}{% endif %}">Type</th>
                             <th data-sort="disposition" class="{% if sort_by == 'disposition' %}sort-{{ sort_order }}{% endif %}">Disposition</th>
-                            <th>Location</th>
+                            <th data-sort="location" class="{% if sort_by == 'location' %}sort-{{ sort_order }}{% endif %}">Location</th>
                             <th data-sort="created_at" class="{% if sort_by == 'created_at' %}sort-{{ sort_order }}{% endif %}">Created</th>
                             <th>Access</th>
                             <th></th>
@@ -188,8 +188,8 @@
                 <table class="items-table">
                     <thead>
                         <tr>
-                            <th>Name</th>
-                            <th>Source</th>
+                            <th data-sort="name" class="{% if sort_by == 'name' %}sort-{{ sort_order }}{% endif %}">Name</th>
+                            <th data-sort="source" class="{% if sort_by == 'source' %}sort-{{ sort_order }}{% endif %}">Source</th>
                             <th>Experiment #</th>
                             <th>Notes</th>
                             <th>Access</th>
@@ -221,7 +221,7 @@
                 <table class="items-table">
                     <thead>
                         <tr>
-                            <th>Name</th>
+                            <th data-sort="name" class="{% if sort_by == 'name' %}sort-{{ sort_order }}{% endif %}">Name</th>
                             <th>Description</th>
                             <th></th>
                         </tr>
@@ -248,7 +248,7 @@
                 <table class="items-table">
                     <thead>
                         <tr>
-                            <th>Name</th>
+                            <th data-sort="name" class="{% if sort_by == 'name' %}sort-{{ sort_order }}{% endif %}">Name</th>
                             <th>Description</th>
                             <th></th>
                         </tr>


### PR DESCRIPTION
## Summary
- Aliquot **Location** column now has `data-sort="location"` — sorts by device name; was the only missing column from #118
- **Sample** table: Name and Source headers are clickable to sort (source sorts by name, not FK id)
- **Aliquot Type** and **Source** tables: Name header is clickable to sort
- The existing sort JS handler from #118 works for all tables with no changes

## Test plan
- [ ] `uv run python manage.py test sample` passes
- [ ] Clicking Location header on aliquot list sorts by storage device name
- [ ] Clicking Name on Sample/Source/Aliquot Type lists sorts correctly, caret appears

Closes #144