### PR TITLE
fix: remove Access column from aliquot table (#129)

### DIFF
--- a/krill/sample/tests/test_views.py
+++ b/krill/sample/tests/test_views.py
@@ -211,6 +211,14 @@ class SampleListViewTest(SampleViewTest):
         response = self.client.get(reverse('sample:sample_list') + '?sort=name&order=asc')
         self.assertContains(response, 'sort-asc')
 
+    def test_aliquot_table_has_no_access_column(self):
+        """Access column is removed from the aliquot table header."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('sample:sample_list') + '?type=aliquot')
+        content = response.content.decode()
+        # Access header should not appear in the aliquot thead
+        self.assertNotIn('<th>Access</th>', content)
+
     def test_aliquot_location_cell_has_title_with_full_path(self):
         """Location cell renders a title attribute with the full storage path."""
         location = AliquotLocation.objects.create(

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -149,7 +149,6 @@
                             <th data-sort="disposition" class="{% if sort_by == 'disposition' %}sort-{{ sort_order }}{% endif %}">Disposition</th>
                             <th data-sort="location" class="{% if sort_by == 'location' %}sort-{{ sort_order }}{% endif %}">Location</th>
                             <th data-sort="created_at" class="{% if sort_by == 'created_at' %}sort-{{ sort_order }}{% endif %}">Created</th>
-                            <th>Access</th>
                             <th></th>
                         </tr>
                     </thead>
@@ -170,7 +169,6 @@
                                 {% else %}—{% endif %}
                             </td>
                             <td>{{ item.created_at|date:"Y-m-d" }}</td>
-                            <td>{{ item.get_access_level_display }}</td>
                             <td>
                                 <a class="action-button view" href="{% url 'sample:detail' type='aliquot' pk=item.id %}" target="_blank" title="Open in new tab">
                                     <span class="material-icons-round">open_in_new</span>
@@ -178,7 +176,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="7" style="text-align:center">No aliquots found.</td></tr>
+                        <tr><td colspan="6" style="text-align:center">No aliquots found.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- Removes the Access column (`<th>` and `<td>`) from the aliquot list table
- Every row showed "All Lab Members" with no variation — reclaims horizontal space
- Empty-state `colspan` updated from 7 → 6

## Test plan
- [ ] `uv run python manage.py test sample` passes
- [ ] Access column no longer visible on `/samples/list/?type=aliquot`

Closes #129