### PR TITLE
fix: rename 'Edit Storage' to 'Manage Storage' (#136)

### DIFF
--- a/krill/templates/storage/storage.html
+++ b/krill/templates/storage/storage.html
@@ -52,8 +52,8 @@
                 Find Aliquot
             </a>
             <a href="{% url 'storage:device_list' %}" class="action-btn">
-                <span class="material-icons-round">edit</span>
-                Edit Storage
+                <span class="material-icons-round">settings</span>
+                Manage Storage
             </a>
             <a href="{% url 'reports:alert_list' %}" class="action-btn">
                 <span class="material-icons-round">warning</span>


### PR DESCRIPTION
## Summary
- Renames the quick-action button on the storage dashboard from "Edit Storage" → "Manage Storage"
- Swaps icon from `edit` → `settings` to better reflect navigating to device management
- No behavior change — link still goes to `storage:device_list`

## Test plan
- [ ] `uv run python manage.py test` passes
- [ ] Storage dashboard shows "Manage Storage" with settings icon

Closes #136