### PR TITLE
feat: improve empty state messaging across all list views (#128)

### DIFF
--- a/krill/templates/krill/home.html
+++ b/krill/templates/krill/home.html
@@ -29,14 +29,14 @@
             <span class="material-icons-round">description</span>
             <div class="stat-info">
                 <h3>Reports</h3>
-                <p>{{ stats.recent_reports|default:"0" }} Recent</p>
+                <p>{% if stats.recent_reports %}{{ stats.recent_reports }} this week{% else %}None this week{% endif %}</p>
             </div>
         </a>
         <a href="{% url 'reports:alert_list' %}" class="stat-card clickable">
             <span class="material-icons-round">warning</span>
             <div class="stat-info">
                 <h3>Alerts</h3>
-                <p>{{ stats.alerts|default:"0" }} New</p>
+                <p>{% if stats.alerts %}{{ stats.alerts }} active{% else %}All clear{% endif %}</p>
             </div>
         </a>
     </div>
@@ -82,8 +82,8 @@
                 <div class="activity-item">
                     <span class="material-icons-round">info</span>
                     <div class="activity-info">
-                        <p>No recent activity</p>
-                        <small>System initialized</small>
+                        <p>No activity yet</p>
+                        <small>Create a sample or aliquot to get started</small>
                     </div>
                 </div>
             {% endif %}

--- a/krill/templates/reports/alert_list.html
+++ b/krill/templates/reports/alert_list.html
@@ -96,7 +96,7 @@
                     </td>
                 </tr>
                 {% empty %}
-                <tr><td colspan="6" style="text-align:center">No alerts found.</td></tr>
+                <tr><td colspan="6" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No active alerts. Alerts are raised automatically when a freezer crosses 90% capacity or a sample passes its expiry date.</td></tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/krill/templates/reports/report_list.html
+++ b/krill/templates/reports/report_list.html
@@ -120,7 +120,7 @@
                     </td>
                 </tr>
                 {% empty %}
-                <tr><td colspan="7" style="text-align:center">No reports found.</td></tr>
+                <tr><td colspan="7" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No reports yet. Reports are generated automatically as lab activity is logged.</td></tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/krill/templates/sample/list.html
+++ b/krill/templates/sample/list.html
@@ -176,7 +176,13 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="6" style="text-align:center">No aliquots found.</td></tr>
+                        <tr><td colspan="6" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">
+{% if search_query or disposition_filter or aliquot_type_filter %}
+No aliquots match your filters — try clearing a filter above.
+{% else %}
+No aliquots yet. <a href="{% url 'sample:sample_create' %}?type=aliquot">Create your first aliquot</a> to get started.
+{% endif %}
+</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -209,7 +215,9 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="6" style="text-align:center">No samples found.</td></tr>
+                        <tr><td colspan="6" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">
+{% if search_query %}No samples match "{{ search_query }}".{% else %}No samples yet. <a href="{% url 'sample:sample_create' %}">Create your first sample</a> to get started.{% endif %}
+</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -236,7 +244,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="3" style="text-align:center">No aliquot types found.</td></tr>
+                        <tr><td colspan="3" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No aliquot types defined yet. <a href="{% url 'sample:sample_create' %}?type=aliquot-type">Add an aliquot type</a> before creating aliquots.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -263,7 +271,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="3" style="text-align:center">No sources found.</td></tr>
+                        <tr><td colspan="3" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No sources defined yet. <a href="{% url 'sample:sample_create' %}?type=source">Add a source</a> to start tracking where samples come from.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>

--- a/krill/templates/storage/list.html
+++ b/krill/templates/storage/list.html
@@ -102,7 +102,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="3" style="text-align:center">No sites found.</td></tr>
+                        <tr><td colspan="3" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No sites configured yet. <a href="{% url 'storage:create' %}?type=site">Add a site</a> to start organizing your storage infrastructure.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -133,7 +133,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="5" style="text-align:center">No devices found.</td></tr>
+                        <tr><td colspan="5" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No freezers or storage units yet. <a href="{% url 'storage:create' %}?type=device">Add a device</a> to start tracking storage capacity.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -164,7 +164,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="5" style="text-align:center">No shelves found.</td></tr>
+                        <tr><td colspan="5" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No shelves yet. <a href="{% url 'storage:create' %}?type=shelf">Add a shelf</a> to a device to organize boxes.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>
@@ -197,7 +197,7 @@
                             </td>
                         </tr>
                         {% empty %}
-                        <tr><td colspan="6" style="text-align:center">No boxes found.</td></tr>
+                        <tr><td colspan="6" style="text-align:center;padding:2rem;color:var(--color-dark-variant)">No boxes yet. <a href="{% url 'storage:create' %}?type=box">Add a box</a> to a shelf to store aliquots.</td></tr>
                         {% endfor %}
                     </tbody>
                 </table>


### PR DESCRIPTION
## Summary
Every empty state now answers: *what would appear here, and how do I make it happen?*

- **Dashboard**: stat cards show "None this week" / "All clear" instead of "0 Recent" / "0 New"; activity feed shows an onboarding hint instead of "No recent activity"
- **Sample list (aliquots)**: filter-aware — "No aliquots match your filters — try clearing a filter" when filters active; "Create your first aliquot" link when list is truly empty
- **Sample list (samples/types/sources)**: each empty state links to the create action with a one-line explanation
- **Storage list (sites/devices/shelves/boxes)**: each links to create the missing item
- **Alerts**: explains that alerts trigger at 90% capacity / expiry
- **Reports**: explains reports are auto-generated from activity

## Test plan
- [ ] `uv run python manage.py test` passes
- [ ] Dashboard with no data shows helpful hints, not "0 Recent"
- [ ] Aliquot list with active filters shows filter-aware message
- [ ] Empty storage list shows actionable links

Closes #128