### PR TITLE
fix: accept model disposition values in CSV import (#90)

### DIFF
--- a/DATA_IMPORT.md
+++ b/DATA_IMPORT.md
@@ -37,7 +37,7 @@ The CSV file must include the following columns (in any order):
 | `Position 4` | No | Column position within the box (1-based) | "5" |
 | `Aliquot Type` | Yes | Type of aliquot | "Cells", "DNA", "RNA" |
 | `Number of Aliquots Total` | Yes | Total number of tubes/aliquots | "6" |
-| `Disposition` | Yes | Current status of the aliquot | "In Storage", "Used", "Checked Out", "Disposed" |
+| `Disposition` | Yes | Current status of the aliquot | "stored", "in_use", "exhausted", "disposed" (or legacy aliases) |
 
 \* Required if you want to assign storage locations. If omitted, samples will be imported without storage assignments.
 
@@ -102,13 +102,21 @@ The storage hierarchy is built automatically:
 ### Disposition
 - Current status of the aliquot
 - Creates a new AliquotDisposition record if it doesn't exist
-- Valid values (these are the CSV column values — the model stores them as the mapped `disposition_type`):
-  - `"In Storage"` → Maps to disposition type `stored`
-  - `"Used"` → Maps to disposition type `exhausted`
-  - `"Checked Out"` → Maps to disposition type `in_use`
-  - `"Disposed"` → Maps to disposition type `disposed` (add this to the mapping if needed)
-  - Any other value → Maps to `stored` (default)
-- The internal AliquotDisposition model uses types: `stored`, `in_use`, `exhausted`, `disposed`
+- Accepted values:
+
+  | CSV value | Disposition type |
+  |-----------|-----------------|
+  | `stored` | stored |
+  | `in_use` | in_use |
+  | `exhausted` | exhausted |
+  | `disposed` | disposed |
+  | `"In Storage"` *(legacy)* | stored |
+  | `"Used"` *(legacy)* | exhausted |
+  | `"Checked Out"` *(legacy)* | in_use |
+  | `"Disposed"` *(legacy)* | disposed |
+
+- Any unrecognised value defaults to `stored`
+- Use the short model values (`stored`, `in_use`, etc.) for new imports; legacy aliases are still accepted for backwards compatibility
 
 ## Example CSV File
 

--- a/krill/person/admin.py
+++ b/krill/person/admin.py
@@ -288,9 +288,16 @@ class DataImportView(TemplateView):
 
             # Map disposition
             disposition_map = {
+                # Legacy CSV aliases
                 'In Storage': 'stored',
                 'Used': 'exhausted',
-                'Checked Out': 'in_use'
+                'Checked Out': 'in_use',
+                'Disposed': 'disposed',
+                # Model values accepted directly
+                'stored': 'stored',
+                'in_use': 'in_use',
+                'exhausted': 'exhausted',
+                'disposed': 'disposed',
             }
             disposition = row.get('Disposition') or 'In Storage'
             disp_type = disposition_map.get(disposition, 'stored')

--- a/krill/person/tests/test_views.py
+++ b/krill/person/tests/test_views.py
@@ -775,6 +775,40 @@ MDA MB 134VI (MM134);UPMC/MJS;Sikora LN2 #1;4;F;1;2;Cells;3;Checked Out;Legacy M
         sources = [f for f in fixtures if f['model'] == 'sample.source']
         self.assertGreater(len(sources), 0)
 
+    def _disposition_csv(self, rows):
+        """Build a minimal valid CSV with given (cell_line, disposition) rows."""
+        header = "Cell Line;Source;Freezer Name;Position 1;Position 2;Aliquot Type;Number of Aliquots Total;Disposition;Sample Notes;Experiment #\n"
+        body = "".join(f"{cl};Lab;FreezerA;1;A;Cells;1;{disp};;\n" for cl, disp in rows)
+        return (header + body).encode('utf-8')
+
+    def _disp_types_from_fixtures(self, fixtures):
+        disp_map = {f['pk']: f['fields']['disposition_type'] for f in fixtures if f['model'] == 'sample.aliquotdisposition'}
+        return {disp_map[a['fields']['disposition']] for a in fixtures if a['model'] == 'sample.aliquot'}
+
+    def test_disposition_model_values_accepted_directly(self):
+        """CSV using model disposition values (stored, in_use, exhausted, disposed) imports correctly."""
+        fixtures = self._csv_fixtures_from_bytes(self._disposition_csv([
+            ('SampleA', 'stored'), ('SampleB', 'in_use'),
+            ('SampleC', 'exhausted'), ('SampleD', 'disposed'),
+        ]))
+        disp_types = self._disp_types_from_fixtures(fixtures)
+        self.assertIn('stored', disp_types)
+        self.assertIn('in_use', disp_types)
+        self.assertIn('exhausted', disp_types)
+        self.assertIn('disposed', disp_types)
+
+    def test_disposition_legacy_aliases_still_accepted(self):
+        """Legacy CSV aliases (In Storage, Checked Out, Used, Disposed) still import correctly."""
+        fixtures = self._csv_fixtures_from_bytes(self._disposition_csv([
+            ('SampleA', 'In Storage'), ('SampleB', 'Checked Out'),
+            ('SampleC', 'Used'), ('SampleD', 'Disposed'),
+        ]))
+        disp_types = self._disp_types_from_fixtures(fixtures)
+        self.assertIn('stored', disp_types)
+        self.assertIn('in_use', disp_types)
+        self.assertIn('exhausted', disp_types)
+        self.assertIn('disposed', disp_types)
+
     def test_convert_csv_missing_required_columns_gives_helpful_error(self):
         """Missing required columns raise an error that names both missing and found columns."""
         bad_csv = b'Name;Value\nTest;123\n'

--- a/krill/person/views.py
+++ b/krill/person/views.py
@@ -544,10 +544,16 @@ class DataImportView(TemplateView):
 
                 # Map disposition
                 disposition_map = {
+                    # Legacy CSV aliases
                     'In Storage': 'stored',
                     'Used': 'exhausted',
                     'Checked Out': 'in_use',
                     'Disposed': 'disposed',
+                    # Model values accepted directly
+                    'stored': 'stored',
+                    'in_use': 'in_use',
+                    'exhausted': 'exhausted',
+                    'disposed': 'disposed',
                 }
                 disposition = row['Disposition'] or 'In Storage'
                 disp_type = disposition_map.get(disposition, 'stored')


### PR DESCRIPTION
## Summary
- CSV import now accepts both model values (`stored`, `in_use`, `exhausted`, `disposed`) and legacy aliases (`"In Storage"`, `"Checked Out"`, etc.) in both `person/views.py` and `person/admin.py`
- Updates `DATA_IMPORT.md` with a clear table of all accepted values; recommends model values for new imports

## Test plan
- [ ] `uv run python manage.py test` passes
- [ ] CSV with `disposition=stored` imports correctly (was silently defaulting to stored before, now explicit)
- [ ] CSV with `disposition=In Storage` still imports correctly (backwards compat)

Closes #90