### PR TITLE
chore: remove Redis from config, docs, and docker-compose

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -73,9 +73,9 @@ The project includes several environment file templates:
 
 ### Using Docker Compose
 
-1. **Start PostgreSQL and Redis:**
+1. **Start PostgreSQL:**
    ```bash
-   docker-compose up -d postgres redis
+   docker-compose up -d postgres
    ```
 
 2. **Set environment variables:**
@@ -264,7 +264,6 @@ python manage.py setup_db --check
    - Monitor query performance with `django-debug-toolbar`
 
 3. **Caching:**
-   - Enable Redis caching for production
    - Use `select_related()` and `prefetch_related()` for queries
    - Implement database query optimization
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -86,7 +86,6 @@ docker run -p 8000:8000 \
   -e DB_USER=your_db_user \
   -e DB_PASSWORD=your_db_password \
   -e DB_HOST=your_db_host \
-  -e REDIS_URL=redis://your_redis_host:6379/1 \
   krill:production
 ```
 
@@ -113,15 +112,12 @@ docker run -p 8000:8000 \
 - `DB_PASSWORD` (required)
 - `DB_HOST` (required)
 - `DB_PORT=5432`
-- `REDIS_URL` (required)
-
 ## 🗄️ Database Configuration
 
-The containers are designed to work with external databases. You'll need to:
+The containers are designed to work with an external PostgreSQL database. You'll need to:
 
 1. **Set up PostgreSQL** for production
-2. **Set up Redis** for caching and sessions
-3. **Configure environment variables** to point to your databases
+2. **Configure environment variables** to point to your database
 
 ### Example with External Database
 ```bash
@@ -131,7 +127,6 @@ docker run -p 8000:8000 \
   -e DB_USER=krill_user \
   -e DB_PASSWORD=secure_password \
   -e DB_HOST=your-postgres-host \
-  -e REDIS_URL=redis://your-redis-host:6379/1 \
   krill:production
 ```
 

--- a/DO_APP_PLATFORM_QUICK_REF.md
+++ b/DO_APP_PLATFORM_QUICK_REF.md
@@ -30,9 +30,6 @@ DB_SSLMODE=require
 - `DB_HOST=${db.HOST}`
 - `DB_PORT=${db.PORT}`
 
-**These are automatically set when you bind a Redis database:**
-- `REDIS_URL=${redis.REDIS_URL}`
-
 ### 🟢 RECOMMENDED (For Production)
 
 ```bash
@@ -121,9 +118,6 @@ DJANGO_SETTINGS_MODULE=krill.settings_production
 
 # Environment
 ENVIRONMENT=production
-
-# Cache (Auto-configured when binding Redis)
-REDIS_URL=${redis.REDIS_URL}
 
 # Email
 EMAIL_HOST=smtp.gmail.com

--- a/PRODUCTION_DEPLOYMENT.md
+++ b/PRODUCTION_DEPLOYMENT.md
@@ -47,15 +47,6 @@ DJANGO_SETTINGS_MODULE=krill.settings_production
 
 These variables are **HIGHLY RECOMMENDED** for production:
 
-#### Cache Configuration
-```bash
-# Redis Cache URL
-REDIS_URL=redis://your-redis-host:6379/1
-
-# Alternative: Redis with authentication
-REDIS_URL=redis://:password@your-redis-host:6379/1
-```
-
 #### Email Configuration
 ```bash
 # SMTP Settings
@@ -159,13 +150,6 @@ When you bind a PostgreSQL database to your app in DO App Platform, these variab
 - `db.HOST` → `DB_HOST`
 - `db.PORT` → `DB_PORT`
 
-### DO App Platform Redis Binding
-
-If you bind a Redis database:
-```bash
-REDIS_URL=${redis.REDIS_URL}
-```
-
 ## Environment Variable Templates
 
 ### Complete Production Environment File
@@ -194,9 +178,6 @@ DJANGO_SETTINGS_MODULE=krill.settings_production
 
 # Environment
 ENVIRONMENT=production
-
-# Cache Configuration
-REDIS_URL=redis://your-redis-host:6379/1
 
 # Email Configuration
 EMAIL_HOST=smtp.gmail.com
@@ -244,9 +225,6 @@ DJANGO_SETTINGS_MODULE=krill.settings_production
 
 # Environment
 ENVIRONMENT=production
-
-# Cache (if binding Redis)
-REDIS_URL=${redis.REDIS_URL}
 
 # Email
 EMAIL_HOST=smtp.gmail.com
@@ -480,6 +458,4 @@ DJANGO_DEBUG=False
 
 ### Database Resources
 - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
-- [Redis Documentation](https://redis.io/documentation)
-
 Remember: **Never commit sensitive environment variables to version control**. Always use your platform's secure environment variable management system.

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ The project supports both SQLite and PostgreSQL databases:
 ### Using Docker (Recommended)
 
 ```bash
-# Start PostgreSQL and Redis services
-docker-compose up -d postgres redis
+# Start PostgreSQL service
+docker-compose up -d postgres
 
 # Set environment variables
 export DATABASE_ENGINE=postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,20 +21,5 @@ services:
       timeout: 5s
       retries: 5
 
-  redis:
-    image: redis:7-alpine
-    container_name: krill_redis
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis_data:/data
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
 volumes:
   postgres_data:
-  redis_data:

--- a/krill/SECURITY.md
+++ b/krill/SECURITY.md
@@ -57,7 +57,6 @@ This document provides a comprehensive security implementation and deployment gu
 - **Status**: ✅ **IMPLEMENTED** - Production dependencies with security packages
 - **Added Packages**:
   - `psycopg2-binary` - PostgreSQL adapter
-  - `redis`, `django-redis` - Caching and sessions
   - `django-ratelimit`, `django-axes` - Rate limiting and login tracking
   - `python-dotenv`, `django-environ` - Environment management
   - `sentry-sdk` - Error tracking and monitoring
@@ -137,7 +136,6 @@ DB_USER=krill_user
 DB_PASSWORD=secure-database-password
 DB_HOST=localhost
 DB_PORT=5432
-REDIS_URL=redis://127.0.0.1:6379/1
 EMAIL_HOST=smtp.your-provider.com
 EMAIL_HOST_USER=your-email@domain.com
 EMAIL_HOST_PASSWORD=your-email-password

--- a/krill/deploy.py
+++ b/krill/deploy.py
@@ -54,8 +54,6 @@ def check_dependencies():
     required_packages = [
         'django',
         'psycopg2-binary',
-        'redis',
-        'django-redis',
     ]
 
     missing_packages = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,6 @@ typing_extensions==4.9.0
 # Database
 psycopg2-binary==2.9.9  # PostgreSQL adapter for production
 
-# Cache and Sessions
-redis==5.0.1
-django-redis==5.4.0
-
 # Security
 django-ratelimit==4.1.0  # Rate limiting
 django-cors-headers==4.3.1  # CORS handling


### PR DESCRIPTION
## Summary

- Removes `redis` and `django-redis` from `requirements.txt`
- Removes the Redis service and `redis_data` volume from `docker-compose.yml`
- Removes Redis from the `deploy.py` dependency check list
- Strips `REDIS_URL` references and Redis setup instructions from all deployment docs (`DOCKER.md`, `PRODUCTION_DEPLOYMENT.md`, `DO_APP_PLATFORM_QUICK_REF.md`, `SECURITY.md`, `README.md`, `DATABASE_SETUP.md`)

Follows up #153 (pyproject.toml + settings_production.py + dead code removal). Redis was never used in live code — the only `cache.get()` calls were inside dead docstrings. Django's cache layer is lazy and never established a connection, so production ran fine without a Redis server the whole time.

## Test plan
- [x] No `redis` or `REDIS` references remain anywhere in the repo
- [x] Full test suite passes on main (408 tests)
- [x] `docker-compose up -d postgres` is the correct local dev command going forward