### PR TITLE
feat: add Railway deployment support

### DIFF
--- a/krill/krill/settings_production.py
+++ b/krill/krill/settings_production.py
@@ -55,20 +55,27 @@ CSRF_TRUSTED_ORIGINS = [
 # Statement timeout in milliseconds for all queries (default 30 seconds).
 # Prevents long-running queries from hanging the app; override via DB_STATEMENT_TIMEOUT_MS.
 _pg_timeout_ms = os.environ.get('DB_STATEMENT_TIMEOUT_MS', '30000')
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.environ.get('DB_NAME', 'krill_production'),
-        'USER': os.environ.get('DB_USER', 'krill_user'),
-        'PASSWORD': os.environ.get('DB_PASSWORD', ''),
-        'HOST': os.environ.get('DB_HOST', 'localhost'),
-        'PORT': os.environ.get('DB_PORT', '5432'),
-        'OPTIONS': {
-            'sslmode': 'require',
-            'options': f'-c statement_timeout={_pg_timeout_ms}',
-        },
+_pg_options = {'options': f'-c statement_timeout={_pg_timeout_ms}'}
+
+_database_url = os.environ.get('DATABASE_URL')
+if _database_url:
+    # Railway provides a single DATABASE_URL connection string.
+    import dj_database_url
+    DATABASES = {'default': dj_database_url.parse(_database_url, ssl_require=True)}
+    DATABASES['default'].setdefault('OPTIONS', {}).update(_pg_options)
+else:
+    # DO App Platform (and other envs) supply individual DB_* vars.
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.environ.get('DB_NAME', 'krill_production'),
+            'USER': os.environ.get('DB_USER', 'krill_user'),
+            'PASSWORD': os.environ.get('DB_PASSWORD', ''),
+            'HOST': os.environ.get('DB_HOST', 'localhost'),
+            'PORT': os.environ.get('DB_PORT', '5432'),
+            'OPTIONS': {'sslmode': 'require', **_pg_options},
+        }
     }
-}
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = '/static/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 
     # Database
     "psycopg2-binary==2.9.9",
+    "dj-database-url==2.1.0",
 
     # Security
     "django-ratelimit==4.1.0",

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+dockerfilePath = "Dockerfile"
+dockerBuildTarget = "production"
+
+[deploy]
+startCommand = "uv run python manage.py migrate && uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
+healthcheckPath = "/login/"
+healthcheckTimeout = 30

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,19 @@ wheels = [
 ]
 
 [[package]]
+name = "dj-database-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1d/91ca6ded2b97688bc0287240c916690b6ee7ce2fd5327ea83f847730f6ec/dj-database-url-2.1.0.tar.gz", hash = "sha256:f2042cefe1086e539c9da39fad5ad7f61173bf79665e69bf7e4de55fa88b135f", size = 10502, upload-time = "2023-08-15T14:38:12.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/d2/b90366de4682c1472748b848292054e0960673f3c7d1a9d08fb227fad819/dj_database_url-2.1.0-py3-none-any.whl", hash = "sha256:04bc34b248d4c21aaa13e4ab419ae6575ef5f10f3df735ce7da97722caa356e0", size = 7673, upload-time = "2023-08-15T14:39:01.026Z" },
+]
+
+[[package]]
 name = "django"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -470,6 +483,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "asgiref" },
+    { name = "dj-database-url" },
     { name = "django" },
     { name = "django-axes" },
     { name = "django-cors-headers" },
@@ -504,6 +518,7 @@ requires-dist = [
     { name = "asgiref", specifier = "==3.7.2" },
     { name = "bandit", marker = "extra == 'dev'", specifier = "==1.7.5" },
     { name = "coverage", marker = "extra == 'dev'", specifier = "==7.3.2" },
+    { name = "dj-database-url", specifier = "==2.1.0" },
     { name = "django", specifier = "==5.0.1" },
     { name = "django-axes", specifier = "==6.1.0" },
     { name = "django-cors-headers", specifier = "==4.3.1" },


### PR DESCRIPTION
## Summary

- Adds `railway.toml` — tells Railway to build the `production` Dockerfile target and use a start command that runs `migrate` then `gunicorn` on Railway's injected `$PORT`
- Adds `dj-database-url==2.1.0` dependency
- Updates `settings_production.py` to detect `DATABASE_URL` (Railway's format) and parse it with `dj-database-url`; falls back to individual `DB_*` vars so existing DO App Platform deploys are completely unaffected

## Railway setup after merging

In Railway, set these env vars on the web service:
- `DATABASE_URL` → reference var pointing to the Postgres add-on (auto-wired)
- `DJANGO_SECRET_KEY` → generate with `python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"`
- `DJANGO_SETTINGS_MODULE` → `krill.settings_production`
- `DJANGO_ALLOWED_HOSTS` → your `*.up.railway.app` domain

## Test plan
- [x] 408 tests pass unchanged
- [x] `DATABASE_URL` path: parses URL, adds SSL, applies statement timeout
- [x] No `DATABASE_URL`: falls back to `DB_*` vars (existing DO behaviour)