### PR TITLE
fix: cd to correct working directory in Railway start command

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,6 @@ dockerfilePath = "Dockerfile"
 dockerBuildTarget = "production"
 
 [deploy]
-startCommand = "uv run python manage.py migrate && uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
+startCommand = "cd /app/krill && uv run python manage.py migrate && uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
 healthcheckPath = "/login/"
 healthcheckTimeout = 30


### PR DESCRIPTION
Railway runs `startCommand` from `/app` rather than the Dockerfile's `WORKDIR /app/krill`, causing `manage.py` not to be found. Prefixing the command with `cd /app/krill &&` fixes it.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>