### PR TITLE
fix: correct Railway start command and use pre-deploy for migrations

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,7 @@ dockerfilePath = "Dockerfile"
 dockerBuildTarget = "production"
 
 [deploy]
-startCommand = "cd /app/krill && uv run python manage.py migrate && uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
+preDeployCommand = "uv run python /app/krill/manage.py migrate"
+startCommand = "uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
 healthcheckPath = "/login/"
 healthcheckTimeout = 30


### PR DESCRIPTION
## Summary

- Uses full path `/app/krill/manage.py` to avoid working directory issues with Railway's `startCommand`
- Moves `migrate` to `preDeployCommand` so it runs before the container starts (and blocks deploy if it fails)
- Removes the `start.sh` workaround added during iteration

## Test plan
- [ ] Pre-deploy step runs `migrate` successfully in Railway logs
- [ ] Gunicorn starts and app is reachable