### PR TITLE
fix: remove explicit --bind, gunicorn reads PORT env var natively

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerBuildTarget = "production"
 
 [deploy]
 preDeployCommand = "uv run python /app/krill/manage.py migrate"
-startCommand = "/bin/sh -c 'uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application'"
+startCommand = "uv run gunicorn --workers 3 --timeout 120 krill.wsgi:application"
 healthcheckPath = "/login/"
 healthcheckTimeout = 30

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerBuildTarget = "production"
 
 [deploy]
 preDeployCommand = "uv run python /app/krill/manage.py migrate"
-startCommand = "uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application"
+startCommand = "/bin/sh -c 'uv run gunicorn --bind 0.0.0.0:$PORT --workers 3 --timeout 120 krill.wsgi:application'"
 healthcheckPath = "/login/"
 healthcheckTimeout = 30


### PR DESCRIPTION
Gunicorn natively reads the `PORT` environment variable and binds to `0.0.0.0:$PORT` automatically when it's set. Railway injects `PORT=8080` by default, so no `--bind` argument or shell wrapper is needed — and this avoids the shell variable expansion issue entirely.

Sources:
- [Flask/Gunicorn app fails to start on Railway: '\$PORT' is not a valid port number](https://station.railway.com/questions/flask-gunicorn-app-fails-to-start-on-rai-63fe4d78)
- [Gunicorn settings — bind](https://gunicorn.org/reference/settings/)