### PR TITLE
fix: add --chdir so gunicorn finds krill.wsgi

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ dockerBuildTarget = "production"
 
 [deploy]
 preDeployCommand = "uv run python /app/krill/manage.py migrate"
-startCommand = "uv run gunicorn --workers 3 --timeout 120 krill.wsgi:application"
+startCommand = "uv run gunicorn --chdir /app/krill --workers 3 --timeout 120 krill.wsgi:application"
 healthcheckPath = "/login/"
 healthcheckTimeout = 30


### PR DESCRIPTION
Railway ignores the Dockerfile `WORKDIR` for `startCommand`, so gunicorn can't resolve `krill.wsgi` without `--chdir /app/krill`.