### PR TITLE
fix: add Dockerfile.railway for Railway deployments

### DIFF
--- a/Dockerfile.railway
+++ b/Dockerfile.railway
@@ -1,0 +1,27 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_NO_CACHE=1
+
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    libmagic1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+COPY . .
+
+RUN mkdir -p /app/media /app/staticfiles /app/krill/logs
+
+RUN DJANGO_SETTINGS_MODULE=krill.settings_production \
+    uv run python krill/manage.py collectstatic --noinput
+
+RUN groupadd -r krill && useradd -r -g krill krill && chown -R krill:krill /app
+USER krill

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,5 @@
 [build]
-dockerfilePath = "Dockerfile"
-dockerBuildTarget = "production"
+dockerfilePath = "Dockerfile.railway"
 
 [deploy]
 preDeployCommand = "uv run python /app/krill/manage.py migrate"


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.railway` — a clean single-stage build for Railway
- Updates `railway.toml` to use it (removes `dockerBuildTarget`)

## Root cause

Railway's build cache was serving a stale layer for `COPY . .` in the multi-stage Dockerfile. Because all downstream layers hit the cache too, the `collectstatic` RUN step never executed in the deployed image. At runtime, `/app/staticfiles` was empty, causing `CompressedManifestStaticFilesStorage` to throw `ValueError: Missing staticfiles manifest entry for 'images/krill.png'` on every template render — surfaced as 500 → 502.

The single-stage Dockerfile has no cached layers to inherit from, so every build is clean and `collectstatic` always runs.

## Test plan
- [ ] Railway build logs show collectstatic running (not cached)
- [ ] `/login/` returns 200 instead of 500
- [ ] App loads fully with CSS/images

🤖 Generated with [Claude Code](https://claude.com/claude-code)