### PR TITLE
fix: prevent consumables table columns from overlapping

### DIFF
--- a/krill/static/krill/style.css
+++ b/krill/static/krill/style.css
@@ -1196,6 +1196,7 @@ main table tbody tr:last-child td{
 
 .items-table {
     width: 100%;
+    min-width: 800px;
     border-collapse: collapse;
     white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

- Adds `min-width: 800px` to `.items-table` so the existing `overflow-x: auto` on `.table-container` triggers horizontal scroll before columns get squeezed narrow enough to let badge content (Low Stock, Expired, etc.) visually overflow into adjacent cells.

## Test plan

- [ ] Narrow the browser window on the consumables list — table scrolls horizontally instead of overlapping columns
- [ ] Low Stock / Out of Stock / Expired badges stay within the Name column at all viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)