### PR TITLE
Move migration logic into app startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ WORKDIR /app/krill
 EXPOSE 8000
 
 # Production command
-CMD ["uv", "run", "gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "--timeout", "120", "krill.wsgi:application"]
+CMD ["sh", "-c", "uv run python manage.py migrate && uv run gunicorn --bind 0.0.0.0:8000 --workers 3 --timeout 120 krill.wsgi:application"]
 
 # Testing stage
 FROM base as testing


### PR DESCRIPTION
The app.yaml DO app spec is fine, but doesn't get redeployed. Rather than launching another job per-deployment, just make sure that the main app runs migrations before starting.